### PR TITLE
set csghub as default mirror

### DIFF
--- a/pycsghub/cli.py
+++ b/pycsghub/cli.py
@@ -7,11 +7,13 @@ from pycsghub.constants import DEFAULT_CSGHUB_DOMAIN, DEFAULT_REVISION, MIRROR
 
 app = typer.Typer(add_completion=False)
 
+
 def version_callback(value: bool):
     if value:
         pkg_version = version("csghub-sdk")
         print(f"csghub-cli version {pkg_version}")
         raise typer.Exit()
+
 
 OPTIONS = {
     "repoID": typer.Argument(help="The ID of the repo. (e.g. `username/repo-name`)."),
@@ -34,7 +36,7 @@ def download(
     endpoint: Annotated[Optional[str], OPTIONS["endpoint"]] = DEFAULT_CSGHUB_DOMAIN,
     token: Annotated[Optional[str], OPTIONS["token"]] = None,
     cache_dir: Annotated[Optional[str], OPTIONS["cache_dir"]] = None,
-    mirror: Annotated[Optional[str], OPTIONS["mirror"]] = MIRROR.AUTO,
+    mirror: Annotated[Optional[str], OPTIONS["mirror"]] = MIRROR.CSGHUB,
 ):
     repo.download(
         repo_id=repo_id,
@@ -63,7 +65,8 @@ def upload(
         endpoint=endpoint,
         token=token
     )
- 
+
+
 @app.callback(invoke_without_command=True)
 def main(version: bool = OPTIONS["version"]):
     pass

--- a/pycsghub/snapshot_download.py
+++ b/pycsghub/snapshot_download.py
@@ -31,7 +31,7 @@ def snapshot_download(
         headers: Optional[Dict[str, str]] = None,
         endpoint: Optional[str] = None,
         token: Optional[str] = None,
-        mirror: Optional[str] = MIRROR.AUTO,
+        mirror: Optional[str] = MIRROR.CSGHUB,
 ) -> str:
     if repo_type is None:
         repo_type = REPO_TYPE_MODEL
@@ -107,6 +107,6 @@ def snapshot_download(
                 temp_file = os.path.join(temp_cache_dir, repo_file)
                 savedFile = cache.put_file(repo_file_info, temp_file)
                 print(f"Saved file to '{savedFile}'")
-            
+
         cache.save_model_version(revision_info={'Revision': revision})
         return os.path.join(cache.get_root_location())

--- a/pycsghub/utils.py
+++ b/pycsghub/utils.py
@@ -49,9 +49,10 @@ def build_csg_headers(
         csg_headers["authorization"] = f"Bearer {token_to_send}"
     if headers is not None:
         csg_headers.update(headers)
-        
+
     csg_headers["X-OPENCSG-S3-Internal"] = S3_INTERNAL
     return csg_headers
+
 
 def model_id_to_group_owner_name(model_id: str) -> (str, str):
     if MODEL_ID_SEPARATOR in model_id:
@@ -100,7 +101,7 @@ def get_repo_info(
     files_metadata: bool = False,
     token: Union[bool, str, None] = None,
     endpoint: Optional[str] = None,
-    mirror: Optional[str] = MIRROR.AUTO,
+    mirror: Optional[str] = MIRROR.CSGHUB,
 ) -> Union[ModelInfo, DatasetInfo, SpaceInfo]:
     """
     Get the info object for a given repo of a given type.
@@ -168,7 +169,7 @@ def dataset_info(
     files_metadata: bool = False,
     token: Union[bool, str, None] = None,
     endpoint: Optional[str] = None,
-    mirror: Optional[str] = MIRROR.AUTO,
+    mirror: Optional[str] = MIRROR.CSGHUB,
 ) -> DatasetInfo:
     """
     Get info on one specific dataset on huggingface.co.
@@ -286,7 +287,7 @@ def model_info(
     files_metadata: bool = False,
     token: Union[bool, str, None] = None,
     endpoint: Optional[str] = None,
-    mirror: Optional[str] = MIRROR.AUTO,
+    mirror: Optional[str] = MIRROR.CSGHUB,
 ) -> ModelInfo:
     """
     Note: It is a huggingface method moved here to adjust csghub server response.
@@ -363,7 +364,7 @@ def get_file_download_url(
     revision: str,
     repo_type: Optional[str] = None,
     endpoint: Optional[str] = None,
-    mirror: Optional[str] = MIRROR.AUTO,
+    mirror: Optional[str] = MIRROR.CSGHUB,
 ) -> str:
     """Format file download url according to `model_id`, `revision` and `file_path`.
     Args:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='csghub-sdk',
-    version='0.4.0',
+    version='0.4.1',
     author="opencsg",
     author_email="contact@opencsg.com",
     long_description=long_description,


### PR DESCRIPTION
Traceback (most recent call last):
  File "/workspace/entry.py", line 10, in <module>
    snapshot_download(REPO_ID, cache_dir=DOWNLOAD_DIR, endpoint=ENDPOINT, token=TOKEN)
  File "/usr/local/lib/python3.10/dist-packages/pycsghub/snapshot_download.py", line 63, in snapshot_download
    repo_info = utils.get_repo_info(repo_id,
  File "/usr/local/lib/python3.10/dist-packages/pycsghub/utils.py", line 152, in get_repo_info
    return method(
  File "/usr/local/lib/python3.10/dist-packages/pycsghub/utils.py", line 341, in model_info
    r.raise_for_status()
  File "/usr/local/lib/python3.10/dist-packages/requests/models.py", line 1024, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://hub.opencsg.com/hf/api/models/Qwen/Qwen2-7B-Instruct/revision/main?mirror=auto