### PR TITLE
add allow and ignore patterns options

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ export CSG_TOKEN=your_access_token
 # download model
 csghub-cli download wanghh2000/myprivate1
 
+# download model with allow patterns '*.json' and ignore '*_config.json' pattern of files
+csghub-cli download wanghh2000/myprivate1 --allow-patterns "*.json" --ignore-patterns "*_config.json"
+
 # download dataset
 csghub-cli download wanghh2000/myds1 -t dataset
 
@@ -125,6 +128,20 @@ endpoint = "https://hub.opencsg.com"
 repo_id = 'OpenCSG/csg-wukong-1B'
 cache_dir = '/Users/hhwang/temp/'
 result = snapshot_download(repo_id, cache_dir=cache_dir, endpoint=endpoint, token=token)
+```
+
+### Download model with allow patterns '*.json' and ignore '*_config.json' pattern of files
+
+```python
+from pycsghub.snapshot_download import snapshot_download
+token = "your_access_token"
+
+endpoint = "https://hub.opencsg.com"
+repo_id = 'OpenCSG/csg-wukong-1B'
+cache_dir = '/Users/hhwang/temp/'
+allow_patterns = ["*.json"]
+ignore_patterns = ["*_config.json"]
+result = snapshot_download(repo_id, cache_dir=cache_dir, endpoint=endpoint, token=token, allow_patterns=allow_patterns, ignore_patterns=ignore_patterns)
 ```
 
 ### Download dataset 

--- a/README_cn.md
+++ b/README_cn.md
@@ -87,6 +87,9 @@ export CSG_TOKEN=your_access_token
 # 模型下载
 csghub-cli download wanghh2000/myprivate1 
 
+# 模型下载时允许'*.json'模式的文件并忽略'*_config.json'模式的文件
+csghub-cli download wanghh2000/myprivate1 --allow-patterns "*.json" --ignore-patterns "*_config.json"
+
 # 数据集下载
 csghub-cli download wanghh2000/myds1 -t dataset
 
@@ -123,6 +126,20 @@ repo_type = "model"
 repo_id = 'OpenCSG/csg-wukong-1B'
 cache_dir = '/Users/hhwang/temp/'
 result = snapshot_download(repo_id, repo_type=repo_type, cache_dir=cache_dir, endpoint=endpoint, token=token,)
+```
+
+### 模型下载时允许'*.json'模式的文件并忽略'*_config.json'模式的文件
+
+```python
+from pycsghub.snapshot_download import snapshot_download
+token = "your_access_token"
+
+endpoint = "https://hub.opencsg.com"
+repo_id = 'OpenCSG/csg-wukong-1B'
+cache_dir = '/Users/hhwang/temp/'
+allow_patterns = ["*.json"]
+ignore_patterns = ["*_config.json"]
+result = snapshot_download(repo_id, cache_dir=cache_dir, endpoint=endpoint, token=token, allow_patterns=allow_patterns, ignore_patterns=ignore_patterns)
 ```
 
 ### 数据集下载

--- a/pycsghub/cli.py
+++ b/pycsghub/cli.py
@@ -40,7 +40,6 @@ def download(
         allow_patterns: Annotated[Optional[List[str]], OPTIONS["allow_patterns"]] = None,
         ignore_patterns: Annotated[Optional[List[str]], OPTIONS["ignore_patterns"]] = None,
     ):
-    print('allow_patterns', allow_patterns)
     repo.download(
         repo_id=repo_id,
         repo_type=repo_type, 

--- a/pycsghub/cli.py
+++ b/pycsghub/cli.py
@@ -24,6 +24,8 @@ OPTIONS = {
     "endpoint": typer.Option("-e", "--endpoint", help="The address of the request to be sent."),
     "username": typer.Option("-u", "--username", help="Logon account of OpenCSG Hub."),
     "token": typer.Option("-k", "--token", help="A User Access Token generated from https://opencsg.com/settings/access-token"),
+    "allow_patterns": typer.Option("--allow-patterns", help="Allow patterns for files to be downloaded."),
+    "ignore_patterns": typer.Option("--ignore-patterns", help="Ignore patterns for files to be downloaded."),
     "version": typer.Option(None, "-V", "--version", callback=version_callback, is_eager=True, help="Show the version and exit."),
 }
 
@@ -35,14 +37,19 @@ def download(
         endpoint: Annotated[Optional[str], OPTIONS["endpoint"]] = DEFAULT_CSGHUB_DOMAIN,
         token: Annotated[Optional[str], OPTIONS["token"]] = None,
         cache_dir: Annotated[Optional[str], OPTIONS["cache_dir"]] = None,
+        allow_patterns: Annotated[Optional[List[str]], OPTIONS["allow_patterns"]] = None,
+        ignore_patterns: Annotated[Optional[List[str]], OPTIONS["ignore_patterns"]] = None,
     ):
+    print('allow_patterns', allow_patterns)
     repo.download(
         repo_id=repo_id,
         repo_type=repo_type, 
         revision=revision, 
         cache_dir=cache_dir,
         endpoint=endpoint,
-        token=token
+        token=token,
+        allow_patterns=allow_patterns,
+        ignore_patterns=ignore_patterns,
     )
 
 @app.command(name="upload", help="Upload repository files to opencsg.com.")

--- a/pycsghub/cmd/repo.py
+++ b/pycsghub/cmd/repo.py
@@ -12,7 +12,9 @@ def download(
         revision: Optional[str] = DEFAULT_REVISION,
         cache_dir: Union[str, Path, None] = None,
         endpoint: Optional[str] = None,
-        token: Optional[str] = None
+        token: Optional[str] = None,
+        allow_patterns: Optional[Union[List[str], str]] = None,
+        ignore_patterns: Optional[Union[List[str], str]] = None,
     ):
     snapshot_download(
         repo_id=repo_id,
@@ -21,6 +23,8 @@ def download(
         cache_dir=cache_dir, 
         endpoint=endpoint, 
         token=token,
+        allow_patterns=allow_patterns,
+        ignore_patterns=ignore_patterns,
     )
 
 def upload_files(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='csghub-sdk',
-    version='0.4.7',
+    version='0.4.8',
     author="opencsg",
     author_email="contact@opencsg.com",
     long_description=long_description,


### PR DESCRIPTION
fix #67 : support files filter

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The MR introduces new options to filter files in the 'pycsghub' Python package. Key updates include:
1. Added 'allow_patterns' and 'ignore_patterns' options in 'cli.py' and 'repo.py' files. These options allow users to specify patterns for files to be downloaded or ignored.
2. The 'download' function in both files has been updated to accept these new options.
3. The package version in 'setup.py' has been updated from '0.4.7' to '0.4.8'.

<!-- @codegpt description end -->