### PR TITLE
allow use docutils 0.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "cryptography>=43.0.1",
         "Cython>=3.0.10",
         "dl>=0.1.0",
-        "docutils>=0.21.2",
+        "docutils>=0.16",
         "HTMLParser>=0.0.2",
         "huggingface_hub>=0.22.2",
         "ipython>=8.12.3",


### PR DESCRIPTION
fix hygon vllm installation issue

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
awscli 1.36.33 requires docutils<0.17,>=0.10, but you have docutils 0.21.2 which is incompatible.
```