### PR TITLE
Update local_dir default path to support back compatibility

### DIFF
--- a/pycsghub/snapshot_download.py
+++ b/pycsghub/snapshot_download.py
@@ -60,7 +60,7 @@ def snapshot_download(
     os.makedirs(temporary_cache_dir, exist_ok=True)
     
     if local_dir is None:
-        local_dir = os.getcwd()
+        local_dir = os.path.join(os.getcwd(), repo_id)
     if isinstance(local_dir, Path):
         local_dir = str(local_dir)
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "csghub-sdk"
-version = "0.8.0"
+version = "0.8.1"
 description = "CSGHub SDK for downloading and uploading models, datasets, and spaces"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
fix #116 

- Change default local_dir to repo_id
- Bump version to 0.8.1 in pyproject.toml