### PR TITLE
feat(sandbox): add async CSGHub sandbox HTTP client

### DIFF
--- a/doc/sdk.md
+++ b/doc/sdk.md
@@ -188,3 +188,18 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
+
+### Sandbox (CLI)
+
+After installing the package, use the `csghub-cli sandbox` command group. Subcommands include `create`, `get`, `start`, `stop`, `delete` (same semantics as `stop`), `exec`, and `health`. Shared options: `-e` / `--endpoint` (Hub `base_url`, default `https://hub.opencsg.com`), `--aigateway-url` for runtime routes when the gateway differs from the Hub, and `-k` / `--token` (optional; otherwise uses `CSGHUB_TOKEN` / token file like the rest of the SDK).
+
+Examples:
+
+```bash
+csghub-cli sandbox create -i your-runner-image:tag -n my-sandbox -k YOUR_TOKEN
+csghub-cli sandbox get my-sandbox -k YOUR_TOKEN
+csghub-cli sandbox exec my-sandbox "echo hello" -k YOUR_TOKEN
+csghub-cli sandbox health my-sandbox -k YOUR_TOKEN
+```
+
+For a full `SandboxCreateRequest` body, pass `--spec path/to/spec.json` instead of `--image` / `--name`. Lifecycle commands print JSON; `exec` streams lines to stdout (exit code 1 if any line starts with `ERROR:`); `health` prints `ok` on success.

--- a/doc/sdk.md
+++ b/doc/sdk.md
@@ -191,7 +191,7 @@ asyncio.run(main())
 
 ### Sandbox (CLI)
 
-After installing the package, use the `csghub-cli sandbox` command group. Subcommands include `create`, `get`, `start`, `stop`, `delete` (same semantics as `stop`), `exec`, and `health`. Shared options: `-e` / `--endpoint` (Hub `base_url`, default `https://hub.opencsg.com`), `--aigateway-url` for runtime routes when the gateway differs from the Hub, and `-k` / `--token` (optional; otherwise uses `CSGHUB_TOKEN` / token file like the rest of the SDK).
+After installing the package, use the `csghub-cli sandbox` command group. Subcommands include `create`, `get`, `start`, `stop`, `delete` (same semantics as `stop`), `exec`, `upload`, and `health`. Shared options: `-e` / `--endpoint` (Hub `base_url`, default `https://hub.opencsg.com`), `--aigateway-url` for runtime routes when the gateway differs from the Hub, and `-k` / `--token` (optional; otherwise uses `CSGHUB_TOKEN` / token file like the rest of the SDK).
 
 Examples:
 
@@ -199,7 +199,8 @@ Examples:
 csghub-cli sandbox create -i your-runner-image:tag -n my-sandbox -k YOUR_TOKEN
 csghub-cli sandbox get my-sandbox -k YOUR_TOKEN
 csghub-cli sandbox exec my-sandbox "echo hello" -k YOUR_TOKEN
+csghub-cli sandbox upload my-sandbox ./local-file.txt -k YOUR_TOKEN
 csghub-cli sandbox health my-sandbox -k YOUR_TOKEN
 ```
 
-For a full `SandboxCreateRequest` body, pass `--spec path/to/spec.json` instead of `--image` / `--name`. Lifecycle commands print JSON; `exec` streams lines to stdout (exit code 1 if any line starts with `ERROR:`); `health` prints `ok` on success.
+For a full `SandboxCreateRequest` body, pass `--spec path/to/spec.json` instead of `--image` / `--name` (`--spec` takes precedence and ignores `--image` / `--name`). Lifecycle commands print JSON; `exec` streams lines to stdout (exit code 1 if any line starts with `ERROR:`); `upload` prints the JSON response message; `health` prints `ok` on success.

--- a/doc/sdk.md
+++ b/doc/sdk.md
@@ -165,3 +165,26 @@ This code:
 2. By generating batch classes dynamically and using class name reflection mechanism, a large number of classes with the same names as those automatically loaded by transformers are created in batches.
 
 3. Assign it with the from_pretrained method, so the model read out will be an hf-transformers model.
+
+### Sandbox (async HTTP client)
+
+The SDK includes `pycsghub.sandbox_client` for CSGHub sandbox lifecycle and runtime APIs (async). Default `base_url` matches the public Hub (`https://hub.opencsg.com`, see `DEFAULT_CSGHUB_DOMAIN`). Set `CsgHubSandboxConfig` if you use a self-hosted Hub or a separate AI Gateway (`aigateway_url`; empty string means runtime calls use the same host as `base_url`).
+
+Authentication uses the same token resolution as the rest of the SDK: optional `token=` on `CsgHubSandbox`, else `CSGHUB_TOKEN` / token file via `get_token_to_send`. HTTP failures raise `SandboxHttpError` or `SandboxTransportError`; `stream_execute_command` yields `ERROR: ...` lines on failure (it does not raise).
+
+```python
+import asyncio
+from pycsghub.sandbox_client import CsgHubSandbox, SandboxCreateRequest
+
+async def main() -> None:
+    client = CsgHubSandbox(token="your_access_token")
+    spec = SandboxCreateRequest(
+        image="your-runner-image:tag",
+        resource_id=77,
+        sandbox_name="my-sandbox",
+    )
+    resp = await client.create_sandbox(spec)
+    print(resp.spec.sandbox_name, resp.state.status)
+
+asyncio.run(main())
+```

--- a/doc/sdk_cn.md
+++ b/doc/sdk_cn.md
@@ -167,3 +167,26 @@ model = AutoModelForCausalLM.from_pretrained('model/repoid')
 2. 通过动态批量类生成与类名反射机制，批量创建大量与transformers自动类加载的重名类。
 
 3. 为其赋予from_pretrained方法，这样读取出来的模型即为hf-transformers模型。
+
+### 沙箱（异步 HTTP 客户端）
+
+SDK 提供 `pycsghub.sandbox_client`，用于 CSGHub 沙箱生命周期与运行时接口（异步）。默认 `base_url` 与公网 Hub 一致（`https://hub.opencsg.com`，见 `DEFAULT_CSGHUB_DOMAIN`）。若使用自建 Hub 或独立 AI 网关，请配置 `CsgHubSandboxConfig`；`aigateway_url` 为空时，运行时请求与 `base_url` 同源。
+
+鉴权与全库一致：可在 `CsgHubSandbox(token=...)` 传入 token，否则使用 `CSGHUB_TOKEN` 或 token 文件（`get_token_to_send`）。一般 HTTP 错误抛出 `SandboxHttpError` 或 `SandboxTransportError`；`stream_execute_command` 在失败时 **仅 yield** `ERROR: ...` 行，不抛异常。
+
+```python
+import asyncio
+from pycsghub.sandbox_client import CsgHubSandbox, SandboxCreateRequest
+
+async def main() -> None:
+    client = CsgHubSandbox(token="your_access_token")
+    spec = SandboxCreateRequest(
+        image="your-runner-image:tag",
+        resource_id=77,
+        sandbox_name="my-sandbox",
+    )
+    resp = await client.create_sandbox(spec)
+    print(resp.spec.sandbox_name, resp.state.status)
+
+asyncio.run(main())
+```

--- a/doc/sdk_cn.md
+++ b/doc/sdk_cn.md
@@ -190,3 +190,18 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
+
+### 沙箱（命令行）
+
+安装本包后，可使用 `csghub-cli sandbox` 子命令组，包含 `create`、`get`、`start`、`stop`、`delete`（与 `stop` 语义相同）、`exec`、`health`。公共参数：`-e` / `--endpoint`（Hub 的 `base_url`，默认 `https://hub.opencsg.com`）、`--aigateway-url`（运行时走独立 AI 网关时填写）、`-k` / `--token`（可选；不传则与全库一致使用 `CSGHUB_TOKEN` 或 token 文件）。
+
+示例：
+
+```bash
+csghub-cli sandbox create -i your-runner-image:tag -n my-sandbox -k YOUR_TOKEN
+csghub-cli sandbox get my-sandbox -k YOUR_TOKEN
+csghub-cli sandbox exec my-sandbox "echo hello" -k YOUR_TOKEN
+csghub-cli sandbox health my-sandbox -k YOUR_TOKEN
+```
+
+若需完整 `SandboxCreateRequest` JSON，可使用 `--spec path/to/spec.json` 代替 `--image` / `--name`。生命周期类命令输出 JSON；`exec` 将流式输出逐行打印到标准输出（任一行以 `ERROR:` 开头则进程退出码为 1）；`health` 成功时打印 `ok`。

--- a/doc/sdk_cn.md
+++ b/doc/sdk_cn.md
@@ -193,7 +193,7 @@ asyncio.run(main())
 
 ### 沙箱（命令行）
 
-安装本包后，可使用 `csghub-cli sandbox` 子命令组，包含 `create`、`get`、`start`、`stop`、`delete`（与 `stop` 语义相同）、`exec`、`health`。公共参数：`-e` / `--endpoint`（Hub 的 `base_url`，默认 `https://hub.opencsg.com`）、`--aigateway-url`（运行时走独立 AI 网关时填写）、`-k` / `--token`（可选；不传则与全库一致使用 `CSGHUB_TOKEN` 或 token 文件）。
+安装本包后，可使用 `csghub-cli sandbox` 子命令组，包含 `create`、`get`、`start`、`stop`、`delete`（与 `stop` 语义相同）、`exec`、`upload`、`health`。公共参数：`-e` / `--endpoint`（Hub 的 `base_url`，默认 `https://hub.opencsg.com`）、`--aigateway-url`（运行时走独立 AI 网关时填写）、`-k` / `--token`（可选；不传则与全库一致使用 `CSGHUB_TOKEN` 或 token 文件）。
 
 示例：
 
@@ -201,7 +201,8 @@ asyncio.run(main())
 csghub-cli sandbox create -i your-runner-image:tag -n my-sandbox -k YOUR_TOKEN
 csghub-cli sandbox get my-sandbox -k YOUR_TOKEN
 csghub-cli sandbox exec my-sandbox "echo hello" -k YOUR_TOKEN
+csghub-cli sandbox upload my-sandbox ./local-file.txt -k YOUR_TOKEN
 csghub-cli sandbox health my-sandbox -k YOUR_TOKEN
 ```
 
-若需完整 `SandboxCreateRequest` JSON，可使用 `--spec path/to/spec.json` 代替 `--image` / `--name`。生命周期类命令输出 JSON；`exec` 将流式输出逐行打印到标准输出（任一行以 `ERROR:` 开头则进程退出码为 1）；`health` 成功时打印 `ok`。
+若需完整 `SandboxCreateRequest` JSON，可使用 `--spec path/to/spec.json` 代替 `--image` / `--name`（`--spec` 优先，传入后会忽略 `--image` / `--name`）。生命周期类命令输出 JSON；`exec` 将流式输出逐行打印到标准输出（任一行以 `ERROR:` 开头则进程退出码为 1）；`upload` 输出 JSON 响应消息；`health` 成功时打印 `ok`。

--- a/examples/sandbox_cli.py
+++ b/examples/sandbox_cli.py
@@ -1,4 +1,4 @@
-"""Use csghub-cli to manage sandboxes (create, get, start, stop, exec, health).
+"""Use csghub-cli to manage sandboxes (create, get, start, stop, exec, upload, health).
 
 Install the package so the ``csghub-cli`` entry point is available::
 
@@ -51,6 +51,7 @@ RUN_EXAMPLES = False
 # Runtime (if gateway differs from Hub, add --aigateway-url)
 #
 #   csghub-cli sandbox exec my-sandbox "echo hello" -e "$ENDPOINT" -k "$CSGHUB_TOKEN"
+#   csghub-cli sandbox upload my-sandbox ./local-file.txt -e "$ENDPOINT" -k "$CSGHUB_TOKEN"
 #   csghub-cli sandbox health my-sandbox -e "$ENDPOINT" -k "$CSGHUB_TOKEN"
 #
 

--- a/examples/sandbox_cli.py
+++ b/examples/sandbox_cli.py
@@ -1,0 +1,93 @@
+"""Use csghub-cli to manage sandboxes (create, get, start, stop, exec, health).
+
+Install the package so the ``csghub-cli`` entry point is available::
+
+    pip install .
+
+If ``csghub-cli`` is not on PATH, use::
+
+    python -m pycsghub.cli sandbox --help
+
+This file documents typical commands. Set RUN_EXAMPLES = True to execute the
+sample ``create`` + ``get`` flow via subprocess (requires a valid token and image).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+# token = "your access token"
+token = None
+
+endpoint = "https://hub.opencsg.com"
+
+# Set True to run the subprocess example at the bottom (optional).
+RUN_EXAMPLES = False
+
+# ---------------------------------------------------------------------------
+# Shell equivalents (run in terminal)
+# ---------------------------------------------------------------------------
+#
+#   export CSGHUB_TOKEN="your access token"
+#   export ENDPOINT="https://hub.opencsg.com"
+#
+# Create (image + name; port 0 means server default)
+#
+#   csghub-cli sandbox create -i your-runner-image:tag -n my-sandbox \\
+#       -e "$ENDPOINT" -k "$CSGHUB_TOKEN"
+#
+# Full JSON body (volumes, many env vars): put SandboxCreateRequest JSON in spec.json
+#
+#   csghub-cli sandbox create --spec /path/to/spec.json -e "$ENDPOINT" -k "$CSGHUB_TOKEN"
+#
+# Query / lifecycle
+#
+#   csghub-cli sandbox get my-sandbox -e "$ENDPOINT" -k "$CSGHUB_TOKEN"
+#   csghub-cli sandbox start my-sandbox -e "$ENDPOINT" -k "$CSGHUB_TOKEN"
+#   csghub-cli sandbox stop my-sandbox -e "$ENDPOINT" -k "$CSGHUB_TOKEN"
+#
+# Runtime (if gateway differs from Hub, add --aigateway-url)
+#
+#   csghub-cli sandbox exec my-sandbox "echo hello" -e "$ENDPOINT" -k "$CSGHUB_TOKEN"
+#   csghub-cli sandbox health my-sandbox -e "$ENDPOINT" -k "$CSGHUB_TOKEN"
+#
+
+
+def _token_arg() -> list[str]:
+    t = token or os.environ.get("CSGHUB_TOKEN")
+    if not t:
+        return []
+    return ["-k", t]
+
+
+def run_subprocess_example() -> None:
+    """Minimal create + get using the same Python process (optional)."""
+    base = [
+        sys.executable,
+        "-m",
+        "pycsghub.cli",
+        "sandbox",
+        "-e",
+        endpoint,
+    ]
+    create = [
+        *base,
+        "create",
+        "-i",
+        "your-runner-image:tag",
+        "-n",
+        "my-sandbox",
+        *_token_arg(),
+    ]
+    get_cmd = [*base, "get", "my-sandbox", *_token_arg()]
+    subprocess.run(create, check=True)
+    subprocess.run(get_cmd, check=True)
+
+
+if __name__ == "__main__":
+    if RUN_EXAMPLES:
+        run_subprocess_example()
+    else:
+        print(__doc__)

--- a/examples/sandbox_sdk.py
+++ b/examples/sandbox_sdk.py
@@ -1,0 +1,57 @@
+"""Use the CSGHub SDK (async) to manage sandboxes: create and query status.
+
+Install: pip install . (from csghub-sdk repo root)
+Requires: httpx, pydantic (declared in pyproject.toml).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from pycsghub.constants import DEFAULT_CSGHUB_DOMAIN
+from pycsghub.sandbox_client import CsgHubSandbox, CsgHubSandboxConfig, SandboxCreateRequest
+
+# token = "your access token"
+token = None
+
+# Hub origin for lifecycle APIs (POST/GET /api/v1/sandboxes). Use your self-hosted URL if needed.
+endpoint = DEFAULT_CSGHUB_DOMAIN
+
+# Optional: if sandbox runtime (exec/health) uses a different host than ``endpoint``, set it here.
+aigateway_url = ""
+
+logging.basicConfig(
+    level=getattr(logging, "INFO"),
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    handlers=[logging.StreamHandler()],
+)
+
+
+async def main() -> None:
+    cfg = CsgHubSandboxConfig(
+        base_url=endpoint,
+        aigateway_url=aigateway_url,
+    )
+    client = CsgHubSandbox(csghub_sandbox_cfg=cfg, token=token)
+
+    spec = SandboxCreateRequest(
+        image="your-runner-image:tag",
+        sandbox_name="my-sandbox",
+        resource_id=77,
+        port=0,
+        timeout=0,
+        environments={"KEY": "value"},
+    )
+
+    created = await client.create_sandbox(spec)
+    print("created:", created.spec.sandbox_name, created.state.status)
+
+    sandbox_id = created.spec.sandbox_name
+    current = await client.get_sandbox(sandbox_id)
+    print("get:", current.spec.image, current.state.status)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pycsghub/cli.py
+++ b/pycsghub/cli.py
@@ -477,12 +477,12 @@ def sandbox_create(
         typer.Option("--timeout", help="EE sandbox idle timeout in seconds (0 = server default)."),
     ] = 0,
     env: Annotated[
-        list[str],
+        Optional[list[str]],
         typer.Option("--env", help="Environment KEY=VALUE (repeatable)."),
-    ] = [],
+    ] = None,
     spec: Annotated[
         Optional[str],
-        typer.Option("--spec", help="JSON file with full SandboxCreateRequest (overrides --image/--name)."),
+        typer.Option("--spec", help="JSON file with full SandboxCreateRequest; if set, --image/--name are ignored."),
     ] = None,
     token: Annotated[Optional[str], OPTIONS["token"]] = None,
     endpoint: Annotated[Optional[str], OPTIONS["endpoint"]] = DEFAULT_CSGHUB_DOMAIN,
@@ -586,6 +586,28 @@ def sandbox_exec(
         endpoint=endpoint,
         aigateway_url=aigateway_url,
         exec_timeout=exec_timeout,
+    )
+
+
+@sandbox_app.command(name="upload", help="Upload a local file to sandbox runtime.", no_args_is_help=True)
+def sandbox_upload(
+    sandbox_name: Annotated[str, typer.Argument(help="Sandbox name.")],
+    local_path: Annotated[str, typer.Argument(help="Local file path to upload.")],
+    timeout: Annotated[
+        float,
+        typer.Option("--timeout", help="HTTP upload timeout in seconds."),
+    ] = 60.0,
+    token: Annotated[Optional[str], OPTIONS["token"]] = None,
+    endpoint: Annotated[Optional[str], OPTIONS["endpoint"]] = DEFAULT_CSGHUB_DOMAIN,
+    aigateway_url: Annotated[Optional[str], OPTIONS["aigateway_url"]] = None,
+):
+    sandbox.upload(
+        sandbox_name=sandbox_name,
+        local_path=local_path,
+        token=token,
+        endpoint=endpoint,
+        aigateway_url=aigateway_url,
+        timeout=timeout,
     )
 
 

--- a/pycsghub/cli.py
+++ b/pycsghub/cli.py
@@ -17,7 +17,7 @@ dotenv.load_dotenv()
 from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 from typing_extensions import Annotated
 
-from pycsghub.cmd import finetune, inference, system
+from pycsghub.cmd import finetune, inference, sandbox, system
 from pycsghub.cmd.repo_types import RepoType
 from pycsghub.constants import DEFAULT_CSGHUB_DOMAIN, DEFAULT_REVISION, REPO_SOURCE_CSG
 from pycsghub.api_client import get_csghub_api
@@ -87,6 +87,10 @@ OPTIONS = {
     "source"            : typer.Option("--source",
                                        help="Specify the source of the repository (e.g. 'csg', 'hf', 'ms')."),
     "path"              : typer.Argument(help="Local path to repository you want to configure."),
+    "aigateway_url"     : typer.Option(
+        "--aigateway-url",
+        help="AI Gateway base URL for sandbox runtime routes; omit to use --endpoint.",
+    ),
 }
 
 @app.command(name="download", help="Download model/dataset/space/code/mcp from OpenCSG Hub", no_args_is_help=True)
@@ -441,6 +445,164 @@ def stop_finetune(
         token=token,
         endpoint=endpoint,
     )
+
+sandbox_app = typer.Typer(
+    no_args_is_help=True,
+    help="Manage CSGHub sandboxes (lifecycle and runtime)",
+)
+app.add_typer(sandbox_app, name="sandbox")
+
+
+@sandbox_app.command(name="create", help="Create a sandbox (POST /api/v1/sandboxes).", no_args_is_help=True)
+def sandbox_create(
+    image: Annotated[
+        Optional[str],
+        typer.Option("--image", "-i", help="Container image (required without --spec)."),
+    ] = None,
+    name: Annotated[
+        Optional[str],
+        typer.Option("--name", "-n", help="Sandbox name (required without --spec)."),
+    ] = None,
+    cluster_id: Annotated[
+        Optional[str],
+        typer.Option("--cluster-id", help="Kubernetes cluster id. (default: empty)"),
+    ] = None,
+    resource_id: Annotated[int, typer.Option("--resource-id", help="Resource pool id.")] = 77,
+    port: Annotated[
+        int,
+        typer.Option("--port", help="Service port (0 = server default, sent in JSON as 0)."),
+    ] = 0,
+    timeout: Annotated[
+        int,
+        typer.Option("--timeout", help="EE sandbox idle timeout in seconds (0 = server default)."),
+    ] = 0,
+    env: Annotated[
+        list[str],
+        typer.Option("--env", help="Environment KEY=VALUE (repeatable)."),
+    ] = [],
+    spec: Annotated[
+        Optional[str],
+        typer.Option("--spec", help="JSON file with full SandboxCreateRequest (overrides --image/--name)."),
+    ] = None,
+    token: Annotated[Optional[str], OPTIONS["token"]] = None,
+    endpoint: Annotated[Optional[str], OPTIONS["endpoint"]] = DEFAULT_CSGHUB_DOMAIN,
+    aigateway_url: Annotated[Optional[str], OPTIONS["aigateway_url"]] = None,
+):
+    sandbox.create(
+        token=token,
+        endpoint=endpoint,
+        aigateway_url=aigateway_url,
+        image=image,
+        name=name,
+        cluster_id=cluster_id or "",
+        resource_id=resource_id,
+        port=port,
+        timeout=timeout,
+        env=env,
+        spec_path=spec,
+    )
+
+
+@sandbox_app.command(name="get", help="Get sandbox status (GET /api/v1/sandboxes/{id}).", no_args_is_help=True)
+def sandbox_get(
+    sandbox_id: Annotated[str, typer.Argument(help="Sandbox id (sandbox_name in API).")],
+    token: Annotated[Optional[str], OPTIONS["token"]] = None,
+    endpoint: Annotated[Optional[str], OPTIONS["endpoint"]] = DEFAULT_CSGHUB_DOMAIN,
+    aigateway_url: Annotated[Optional[str], OPTIONS["aigateway_url"]] = None,
+):
+    sandbox.get_sandbox(
+        sandbox_id=sandbox_id,
+        token=token,
+        endpoint=endpoint,
+        aigateway_url=aigateway_url,
+    )
+
+
+@sandbox_app.command(name="start", help="Start sandbox workload.", no_args_is_help=True)
+def sandbox_start(
+    sandbox_id: Annotated[str, typer.Argument(help="Sandbox id.")],
+    token: Annotated[Optional[str], OPTIONS["token"]] = None,
+    endpoint: Annotated[Optional[str], OPTIONS["endpoint"]] = DEFAULT_CSGHUB_DOMAIN,
+    aigateway_url: Annotated[Optional[str], OPTIONS["aigateway_url"]] = None,
+):
+    sandbox.start(
+        sandbox_id=sandbox_id,
+        token=token,
+        endpoint=endpoint,
+        aigateway_url=aigateway_url,
+    )
+
+
+@sandbox_app.command(name="stop", help="Stop sandbox workload.", no_args_is_help=True)
+def sandbox_stop(
+    sandbox_id: Annotated[str, typer.Argument(help="Sandbox id.")],
+    token: Annotated[Optional[str], OPTIONS["token"]] = None,
+    endpoint: Annotated[Optional[str], OPTIONS["endpoint"]] = DEFAULT_CSGHUB_DOMAIN,
+    aigateway_url: Annotated[Optional[str], OPTIONS["aigateway_url"]] = None,
+):
+    sandbox.stop(
+        sandbox_id=sandbox_id,
+        token=token,
+        endpoint=endpoint,
+        aigateway_url=aigateway_url,
+    )
+
+
+@sandbox_app.command(
+    name="delete",
+    help="Tear down sandbox resources (same as stop).",
+    no_args_is_help=True,
+)
+def sandbox_delete_cmd(
+    sandbox_id: Annotated[str, typer.Argument(help="Sandbox id.")],
+    token: Annotated[Optional[str], OPTIONS["token"]] = None,
+    endpoint: Annotated[Optional[str], OPTIONS["endpoint"]] = DEFAULT_CSGHUB_DOMAIN,
+    aigateway_url: Annotated[Optional[str], OPTIONS["aigateway_url"]] = None,
+):
+    sandbox.delete_sandbox(
+        sandbox_id=sandbox_id,
+        token=token,
+        endpoint=endpoint,
+        aigateway_url=aigateway_url,
+    )
+
+
+@sandbox_app.command(name="exec", help="Run a shell command in the sandbox (streamed output).", no_args_is_help=True)
+def sandbox_exec(
+    sandbox_name: Annotated[str, typer.Argument(help="Sandbox name.")],
+    command: Annotated[str, typer.Argument(help="Shell command to run.")],
+    exec_timeout: Annotated[
+        float,
+        typer.Option("--exec-timeout", help="HTTP/stream timeout in seconds."),
+    ] = 1800.0,
+    token: Annotated[Optional[str], OPTIONS["token"]] = None,
+    endpoint: Annotated[Optional[str], OPTIONS["endpoint"]] = DEFAULT_CSGHUB_DOMAIN,
+    aigateway_url: Annotated[Optional[str], OPTIONS["aigateway_url"]] = None,
+):
+    sandbox.exec_command(
+        sandbox_name=sandbox_name,
+        command=command,
+        token=token,
+        endpoint=endpoint,
+        aigateway_url=aigateway_url,
+        exec_timeout=exec_timeout,
+    )
+
+
+@sandbox_app.command(name="health", help="Probe sandbox runtime readiness via the gateway.", no_args_is_help=True)
+def sandbox_health(
+    sandbox_name: Annotated[str, typer.Argument(help="Sandbox name.")],
+    token: Annotated[Optional[str], OPTIONS["token"]] = None,
+    endpoint: Annotated[Optional[str], OPTIONS["endpoint"]] = DEFAULT_CSGHUB_DOMAIN,
+    aigateway_url: Annotated[Optional[str], OPTIONS["aigateway_url"]] = None,
+):
+    sandbox.health(
+        sandbox_name=sandbox_name,
+        token=token,
+        endpoint=endpoint,
+        aigateway_url=aigateway_url,
+    )
+
 
 @app.callback(
     invoke_without_command=True,

--- a/pycsghub/cmd/sandbox.py
+++ b/pycsghub/cmd/sandbox.py
@@ -1,0 +1,256 @@
+"""CLI helpers for CSGHub sandbox: sync wrappers around async :class:`~pycsghub.sandbox_client.client.CsgHubSandbox`."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Coroutine, Optional, TypeVar
+
+from pydantic import ValidationError
+
+from pycsghub.constants import DEFAULT_CSGHUB_DOMAIN
+from pycsghub.errors import SandboxHttpError, SandboxResponseParseError, SandboxTransportError
+from pycsghub.sandbox_client.client import CsgHubSandbox
+from pycsghub.sandbox_client.config import CsgHubSandboxConfig
+from pycsghub.sandbox_client.models import SandboxCreateRequest, SandboxResponse
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+def sandbox_config(
+    endpoint: Optional[str],
+    aigateway_url: Optional[str],
+) -> CsgHubSandboxConfig:
+    """Build config; ``endpoint`` maps to Hub lifecycle ``base_url``."""
+    base = (endpoint or DEFAULT_CSGHUB_DOMAIN).strip()
+    gw = (aigateway_url or "").strip()
+    return CsgHubSandboxConfig(base_url=base, aigateway_url=gw)
+
+
+def response_to_json(resp: SandboxResponse) -> str:
+    return json.dumps(
+        resp.model_dump(mode="json"),
+        indent=2,
+        ensure_ascii=False,
+        default=str,
+    )
+
+
+def _print_sandbox_error(e: BaseException) -> None:
+    if isinstance(e, SandboxHttpError):
+        print(f"{e}", file=sys.stderr)
+        if e.detail:
+            print(e.detail, file=sys.stderr)
+    elif isinstance(e, SandboxResponseParseError):
+        print(str(e), file=sys.stderr)
+        if e.detail:
+            print(e.detail, file=sys.stderr)
+    else:
+        print(str(e), file=sys.stderr)
+
+
+def run_lifecycle(coro: Coroutine[Any, Any, T]) -> T:
+    """Run async sandbox call; map SDK errors to stderr + exit 1."""
+    try:
+        return asyncio.run(coro)
+    except (SandboxHttpError, SandboxTransportError, SandboxResponseParseError) as e:
+        _print_sandbox_error(e)
+        raise SystemExit(1) from e
+
+
+def parse_env_pairs(env_list: Optional[list[str]]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if not env_list:
+        return out
+    for item in env_list:
+        if "=" not in item:
+            msg = f"Invalid --env value (expected KEY=VALUE): {item!r}"
+            raise ValueError(msg)
+        key, val = item.split("=", 1)
+        if not key:
+            msg = f"Invalid --env value (empty key): {item!r}"
+            raise ValueError(msg)
+        out[key] = val
+    return out
+
+
+def load_create_spec(path: str) -> SandboxCreateRequest:
+    p = Path(path)
+    text = p.read_text(encoding="utf-8")
+    raw = json.loads(text)
+    return SandboxCreateRequest.model_validate(raw)
+
+
+def create(
+    *,
+    token: Optional[str],
+    endpoint: Optional[str],
+    aigateway_url: Optional[str],
+    image: Optional[str],
+    name: Optional[str],
+    cluster_id: str,
+    resource_id: int,
+    port: int,
+    timeout: int,
+    env: Optional[list[str]],
+    spec_path: Optional[str],
+) -> None:
+    cfg = sandbox_config(endpoint, aigateway_url)
+    try:
+        if spec_path:
+            spec = load_create_spec(spec_path)
+        else:
+            if not image or not name:
+                msg = "Provide --spec PATH to a JSON file, or both --image and --name."
+                raise ValueError(msg)
+            spec = SandboxCreateRequest(
+                image=image,
+                sandbox_name=name,
+                cluster_id=cluster_id,
+                resource_id=resource_id,
+                port=port,
+                timeout=timeout,
+                environments=parse_env_pairs(env),
+            )
+    except (ValueError, ValidationError, OSError, json.JSONDecodeError, UnicodeError) as e:
+        print(str(e), file=sys.stderr)
+        raise SystemExit(1) from e
+
+    logger.info("sandbox create sandbox_name=%s", spec.sandbox_name)
+
+    async def _go() -> SandboxResponse:
+        client = CsgHubSandbox(csghub_sandbox_cfg=cfg, token=token)
+        return await client.create_sandbox(spec)
+
+    resp = run_lifecycle(_go())
+    print(response_to_json(resp))
+
+
+def get_sandbox(
+    *,
+    sandbox_id: str,
+    token: Optional[str],
+    endpoint: Optional[str],
+    aigateway_url: Optional[str],
+) -> None:
+    cfg = sandbox_config(endpoint, aigateway_url)
+    logger.info("sandbox get sandbox_id=%s", sandbox_id)
+
+    async def _go() -> SandboxResponse:
+        client = CsgHubSandbox(csghub_sandbox_cfg=cfg, token=token)
+        return await client.get_sandbox(sandbox_id)
+
+    resp = run_lifecycle(_go())
+    print(response_to_json(resp))
+
+
+def start(
+    *,
+    sandbox_id: str,
+    token: Optional[str],
+    endpoint: Optional[str],
+    aigateway_url: Optional[str],
+) -> None:
+    cfg = sandbox_config(endpoint, aigateway_url)
+    logger.info("sandbox start sandbox_id=%s", sandbox_id)
+
+    async def _go() -> SandboxResponse:
+        client = CsgHubSandbox(csghub_sandbox_cfg=cfg, token=token)
+        return await client.start_sandbox(sandbox_id)
+
+    resp = run_lifecycle(_go())
+    print(response_to_json(resp))
+
+
+def stop(
+    *,
+    sandbox_id: str,
+    token: Optional[str],
+    endpoint: Optional[str],
+    aigateway_url: Optional[str],
+) -> None:
+    cfg = sandbox_config(endpoint, aigateway_url)
+    logger.info("sandbox stop sandbox_id=%s", sandbox_id)
+
+    async def _go() -> None:
+        client = CsgHubSandbox(csghub_sandbox_cfg=cfg, token=token)
+        await client.stop_sandbox(sandbox_id)
+
+    run_lifecycle(_go())
+    print(json.dumps({"status": "ok", "sandbox_id": sandbox_id}, indent=2, ensure_ascii=False))
+
+
+def delete_sandbox(
+    *,
+    sandbox_id: str,
+    token: Optional[str],
+    endpoint: Optional[str],
+    aigateway_url: Optional[str],
+) -> None:
+    """Tear down sandbox resources (same HTTP as stop)."""
+    cfg = sandbox_config(endpoint, aigateway_url)
+    logger.info("sandbox delete sandbox_id=%s", sandbox_id)
+
+    async def _go() -> None:
+        client = CsgHubSandbox(csghub_sandbox_cfg=cfg, token=token)
+        await client.delete_sandbox(sandbox_id)
+
+    run_lifecycle(_go())
+    print(json.dumps({"status": "ok", "sandbox_id": sandbox_id}, indent=2, ensure_ascii=False))
+
+
+def exec_command(
+    *,
+    sandbox_name: str,
+    command: str,
+    token: Optional[str],
+    endpoint: Optional[str],
+    aigateway_url: Optional[str],
+    exec_timeout: float,
+) -> None:
+    cfg = sandbox_config(endpoint, aigateway_url)
+    logger.info("sandbox exec sandbox_name=%s", sandbox_name)
+
+    async def _go() -> bool:
+        failed = False
+        client = CsgHubSandbox(csghub_sandbox_cfg=cfg, token=token)
+        async for line in client.stream_execute_command(
+            sandbox_name,
+            command,
+            timeout=exec_timeout,
+        ):
+            print(line)
+            if line.startswith("ERROR:"):
+                failed = True
+        return failed
+
+    try:
+        failed = asyncio.run(_go())
+    except (SandboxHttpError, SandboxTransportError, SandboxResponseParseError) as e:
+        _print_sandbox_error(e)
+        raise SystemExit(1) from e
+    if failed:
+        raise SystemExit(1)
+
+
+def health(
+    *,
+    sandbox_name: str,
+    token: Optional[str],
+    endpoint: Optional[str],
+    aigateway_url: Optional[str],
+) -> None:
+    cfg = sandbox_config(endpoint, aigateway_url)
+    logger.info("sandbox health sandbox_name=%s", sandbox_name)
+
+    async def _go() -> None:
+        client = CsgHubSandbox(csghub_sandbox_cfg=cfg, token=token)
+        await client.get_sandbox_runtime_health(sandbox_name)
+
+    run_lifecycle(_go())
+    print("ok")

--- a/pycsghub/cmd/sandbox.py
+++ b/pycsghub/cmd/sandbox.py
@@ -15,7 +15,7 @@ from pycsghub.constants import DEFAULT_CSGHUB_DOMAIN
 from pycsghub.errors import SandboxHttpError, SandboxResponseParseError, SandboxTransportError
 from pycsghub.sandbox_client.client import CsgHubSandbox
 from pycsghub.sandbox_client.config import CsgHubSandboxConfig
-from pycsghub.sandbox_client.models import SandboxCreateRequest, SandboxResponse
+from pycsghub.sandbox_client.models import SandboxCreateRequest, SandboxResponse, SandboxUploadFileResponse
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +42,7 @@ def response_to_json(resp: SandboxResponse) -> str:
 
 
 def _print_sandbox_error(e: BaseException) -> None:
+    logger.error("sandbox command failed: %s", e)
     if isinstance(e, SandboxHttpError):
         print(f"{e}", file=sys.stderr)
         if e.detail:
@@ -229,13 +230,53 @@ def exec_command(
                 failed = True
         return failed
 
-    try:
-        failed = asyncio.run(_go())
-    except (SandboxHttpError, SandboxTransportError, SandboxResponseParseError) as e:
-        _print_sandbox_error(e)
-        raise SystemExit(1) from e
+    failed = run_lifecycle(_go())
     if failed:
         raise SystemExit(1)
+
+
+def upload(
+    *,
+    sandbox_name: str,
+    local_path: str,
+    token: Optional[str],
+    endpoint: Optional[str],
+    aigateway_url: Optional[str],
+    timeout: float,
+) -> None:
+    cfg = sandbox_config(endpoint, aigateway_url)
+    path_obj = Path(local_path)
+    if not path_obj.exists():
+        print(f"No such file: {local_path}", file=sys.stderr)
+        raise SystemExit(1)
+    if not path_obj.is_file():
+        print(f"Local path must be a file: {local_path}", file=sys.stderr)
+        raise SystemExit(1)
+    try:
+        file_bytes = path_obj.read_bytes()
+    except OSError as e:
+        print(str(e), file=sys.stderr)
+        raise SystemExit(1) from e
+
+    logger.info("sandbox upload sandbox_name=%s file=%s", sandbox_name, path_obj.name)
+
+    async def _go() -> SandboxUploadFileResponse:
+        client = CsgHubSandbox(csghub_sandbox_cfg=cfg, token=token)
+        return await client.upload_file(
+            sandbox_name=sandbox_name,
+            file_name=path_obj.name,
+            file_bytes=file_bytes,
+            timeout=timeout,
+        )
+
+    resp = run_lifecycle(_go())
+    print(
+        json.dumps(
+            resp.model_dump(mode="json"),
+            indent=2,
+            ensure_ascii=False,
+        ),
+    )
 
 
 def health(

--- a/pycsghub/errors.py
+++ b/pycsghub/errors.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Optional
+
 
 class NotSupportError(Exception):
     pass
@@ -33,3 +37,40 @@ class FileIntegrityError(Exception):
 
 class FileDownloadError(Exception):
     pass
+
+
+class SandboxError(Exception):
+    """Base class for CSGHub sandbox HTTP client errors."""
+
+
+class SandboxHttpError(SandboxError):
+    """HTTP status error from sandbox lifecycle or gateway APIs."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int,
+        request_url: str,
+        detail: str,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.request_url = request_url
+        self.detail = detail
+
+
+class SandboxTransportError(SandboxError):
+    """Network or transport failure (timeouts, connection errors, etc.)."""
+
+    def __init__(self, message: str, *, request_url: Optional[str] = None) -> None:
+        super().__init__(message)
+        self.request_url = request_url
+
+
+class SandboxResponseParseError(SandboxError):
+    """Failed to parse sandbox API response as expected JSON or models."""
+
+    def __init__(self, message: str, *, detail: Optional[str] = None) -> None:
+        super().__init__(message)
+        self.detail = detail

--- a/pycsghub/sandbox_client/__init__.py
+++ b/pycsghub/sandbox_client/__init__.py
@@ -1,0 +1,39 @@
+"""CSGHub sandbox HTTP client (async)."""
+
+from pycsghub.errors import (
+    SandboxError,
+    SandboxHttpError,
+    SandboxResponseParseError,
+    SandboxTransportError,
+)
+from pycsghub.sandbox_client.client import CsgHubSandbox
+from pycsghub.sandbox_client.config import CsgHubSandboxConfig
+from pycsghub.sandbox_client.models import (
+    RunnerVolumeSpec,
+    SandboxCreateRequest,
+    SandboxCreateResponse,
+    SandboxErrorResponse,
+    SandboxResponse,
+    SandboxState,
+    SandboxUpdateConfigRequest,
+    SandboxUploadFileResponse,
+    SandboxVolume,
+)
+
+__all__ = [
+    "CsgHubSandbox",
+    "CsgHubSandboxConfig",
+    "RunnerVolumeSpec",
+    "SandboxCreateRequest",
+    "SandboxCreateResponse",
+    "SandboxError",
+    "SandboxErrorResponse",
+    "SandboxHttpError",
+    "SandboxResponse",
+    "SandboxResponseParseError",
+    "SandboxState",
+    "SandboxTransportError",
+    "SandboxUpdateConfigRequest",
+    "SandboxUploadFileResponse",
+    "SandboxVolume",
+]

--- a/pycsghub/sandbox_client/client.py
+++ b/pycsghub/sandbox_client/client.py
@@ -1,0 +1,533 @@
+"""Async HTTP client for CSGHub sandbox APIs (Starhub EE/SaaS + sandbox-runtime proxy).
+
+This module implements two *families* of endpoints:
+
+* **Lifecycle (JSON)** — Under ``{base_url}/api/v1/sandboxes``: create, read, patch configuration,
+  start/stop. Responses typically wrap payloads in an ``httpbase`` envelope (``{"msg","data"}``);
+  the client unwraps ``data`` into :class:`~pycsghub.sandbox_client.models.SandboxResponse`.
+* **Runtime (gateway)** — Under ``{aigateway_url}/v1/sandboxes/...`` when ``aigateway_url`` is set,
+  else the same host as ``base_url``: stream shell output, upload files, batch upload/download,
+  and lightweight health checks. These paths use ``?port=8888`` as required by the gateway.
+
+**Errors:** Non-2xx lifecycle calls raise :class:`~pycsghub.errors.SandboxHttpError` or
+:class:`~pycsghub.errors.SandboxTransportError`; malformed JSON raises
+:class:`~pycsghub.errors.SandboxResponseParseError`. :meth:`CsgHubSandbox.stream_execute_command`
+does *not* raise on failure: it yields a single ``ERROR: ...`` line (compatible with Genius-style callers).
+
+**Auth:** Bearer token via ``token=`` or the same resolution as the rest of the SDK
+(``get_token_to_send`` / ``CSGHUB_TOKEN``).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from typing import Any, Dict, Optional
+
+import httpx
+from pydantic import ValidationError
+
+from pycsghub.errors import SandboxHttpError, SandboxResponseParseError, SandboxTransportError
+from pycsghub.sandbox_client.config import CsgHubSandboxConfig
+from pycsghub.sandbox_client.models import (
+    SandboxCreateRequest,
+    SandboxErrorResponse,
+    SandboxResponse,
+    SandboxUpdateConfigRequest,
+    SandboxUploadFileResponse,
+)
+from pycsghub.utils import get_token_to_send
+
+try:
+    from collections.abc import AsyncGenerator
+except ImportError:
+    from typing import AsyncGenerator
+
+logger = logging.getLogger(__name__)
+
+# Default timeout for lifecycle JSON calls (create, get, patch, start/stop).
+_TIMEOUT = 60.0
+
+
+def _api_sandboxes_root(cfg: CsgHubSandboxConfig) -> str:
+    """Return the collection URL for sandbox lifecycle APIs."""
+    base = cfg.base_url.removesuffix("/")
+    return f"{base}/api/v1/sandboxes"
+
+
+def _aigateway_base(cfg: CsgHubSandboxConfig) -> str:
+    """Base URL for ``/v1/sandboxes/...`` runtime routes; falls back to ``base_url`` if unset."""
+    raw = (cfg.aigateway_url or "").strip()
+    return raw.removesuffix("/") if raw else cfg.base_url.removesuffix("/")
+
+
+def _dump_create_body(spec: SandboxCreateRequest) -> dict[str, Any]:
+    """Serialize create request: omit nulls; use JSON field aliases."""
+    return spec.model_dump(mode="json", exclude_none=True, by_alias=True)
+
+
+def _dump_update_config_body(body: SandboxUpdateConfigRequest) -> dict[str, Any]:
+    """Serialize PATCH body: omit nulls and defaults (Go ``omitempty`` parity)."""
+    return body.model_dump(mode="json", exclude_none=True, exclude_defaults=True, by_alias=True)
+
+
+def _log_error_body(text: str) -> str:
+    """Best-effort parse of error JSON for logging; falls back to a truncated raw body."""
+    try:
+        err = SandboxErrorResponse.model_validate_json(text)
+        return err.log_line()
+    except Exception:
+        return text[:500]
+
+
+def _parse_sandbox_response_json(body: object) -> SandboxResponse:
+    """Parse ``SandboxResponse`` from a bare object or ``httpbase`` ``{"data": ...}`` envelope."""
+    try:
+        if not isinstance(body, dict):
+            msg = "sandbox API response must be a JSON object"
+            raise TypeError(msg)
+        if "spec" in body and "state" in body:
+            return SandboxResponse.model_validate(body)
+        if "data" in body:
+            inner = body["data"]
+            if inner is None:
+                msg = "sandbox API response has data: null"
+                raise ValueError(msg)
+            return SandboxResponse.model_validate(inner)
+        return SandboxResponse.model_validate(body)
+    except (TypeError, ValueError, ValidationError) as e:
+        raise SandboxResponseParseError(str(e), detail=str(e)) from e
+
+
+def _log_lifecycle_response(
+    *,
+    span_name: str,
+    trace_label: str,
+    response: SandboxResponse,
+) -> None:
+    """Structured INFO line after successful create/get/start/update."""
+    logger.info(
+        "[CsgHubSandbox] %s response trace=%s sandbox_name=%s status=%s image=%s",
+        span_name,
+        trace_label,
+        response.spec.sandbox_name,
+        response.state.status,
+        response.spec.image,
+    )
+
+
+def _transport_error(e: httpx.RequestError) -> SandboxTransportError:
+    """Wrap httpx transport failures with optional request URL for debugging."""
+    req = e.request
+    url = str(req.url) if req is not None else None
+    return SandboxTransportError(str(e), request_url=url)
+
+
+class CsgHubSandbox:
+    """Async facade for sandbox lifecycle and runtime HTTP APIs.
+
+    Parameters
+    ----------
+    csghub_sandbox_cfg
+        Hub and optional AI Gateway bases. Defaults match the public Hub (see
+        :class:`~pycsghub.sandbox_client.config.CsgHubSandboxConfig`).
+    token
+        Explicit bearer token. If omitted, :func:`~pycsghub.utils.get_token_to_send` supplies one
+        from environment or token file (same behavior as other SDK entry points).
+    """
+
+    def __init__(
+        self,
+        csghub_sandbox_cfg: Optional[CsgHubSandboxConfig] = None,
+        *,
+        token: Optional[str] = None,
+    ) -> None:
+        self._cfg = csghub_sandbox_cfg if csghub_sandbox_cfg is not None else CsgHubSandboxConfig()
+        self._token = token
+
+    def _bearer(self) -> Optional[str]:
+        return get_token_to_send(self._token)
+
+    def _headers(self) -> dict[str, str]:
+        bearer = self._bearer()
+        return {
+            "Authorization": f"Bearer {bearer}",
+            "Content-Type": "application/json",
+        }
+
+    def _auth_headers(self) -> dict[str, str]:
+        bearer = self._bearer()
+        return {"Authorization": f"Bearer {bearer}"}
+
+    def _root(self) -> str:
+        return _api_sandboxes_root(self._cfg)
+
+    def _execute_stream_url(self, sandbox_name: str) -> str:
+        base = _aigateway_base(self._cfg)
+        return f"{base}/v1/sandboxes/{sandbox_name}/execute?port=8888"
+
+    def _upload_url(self, sandbox_name: str) -> str:
+        base = _aigateway_base(self._cfg)
+        return f"{base}/v1/sandboxes/{sandbox_name}/upload?port=8888"
+
+    def _runtime_health_url(self, sandbox_name: str) -> str:
+        base = _aigateway_base(self._cfg)
+        return f"{base}/v1/sandboxes/{sandbox_name}/?port=8888"
+
+    def _upload_files_batch_url(self, sandbox_name: str) -> str:
+        base = _aigateway_base(self._cfg)
+        return f"{base}/v1/sandboxes/{sandbox_name}/upload-files?port=8888"
+
+    def _download_files_batch_url(self, sandbox_name: str) -> str:
+        base = _aigateway_base(self._cfg)
+        return f"{base}/v1/sandboxes/{sandbox_name}/download-files?port=8888"
+
+    async def stream_execute_command(
+        self,
+        sandbox_name: str,
+        command: str,
+        *,
+        timeout: float = 1800.0,
+    ) -> AsyncGenerator[str, None]:
+        """Stream stdout/stderr as newline-delimited chunks from the sandbox runtime.
+
+        Calls ``POST .../v1/sandboxes/{sandbox_name}/execute?port=8888`` with body
+        ``{"command": "<shell>"}``. Empty lines are skipped.
+
+        On HTTP or transport failure, yields exactly one line starting with ``ERROR:`` and does
+        **not** raise (callers that expect exceptions should wrap this generator).
+
+        Parameters
+        ----------
+        timeout
+            Per-request timeout in seconds (default 30 minutes for long-running commands).
+        """
+        url = self._execute_stream_url(sandbox_name)
+        payload = {"command": command}
+        try:
+            async with (
+                # trust_env=False: do not pick up ambient proxy env vars; keeps routing predictable.
+                httpx.AsyncClient(trust_env=False, timeout=timeout) as client,
+                client.stream("POST", url, headers=self._headers(), json=payload) as response,
+            ):
+                response.raise_for_status()
+
+                full_output: list[str] = []
+                async for line in response.aiter_lines():
+                    if line:
+                        full_output.append(line)
+                        yield line
+                if full_output:
+                    complete_output = "\n".join(full_output)
+                    truncated_output = "\n".join(
+                        [line[:100] + "..." if len(line) > 100 else line for line in full_output[:5]],
+                    ) + ("\n..." if len(full_output) > 5 else "")
+                    logger.debug(
+                        "[CsgHubSandbox] exec-command output lines=%s length=%s sample=%s",
+                        len(full_output),
+                        len(complete_output),
+                        truncated_output[:200],
+                    )
+        except httpx.HTTPStatusError as e:
+            try:
+                await e.response.aread()
+                err_body = e.response.text
+            except Exception as read_err:
+                logger.warning(
+                    "Sandbox exec HTTP error body unreadable for %s: %s",
+                    sandbox_name,
+                    read_err,
+                )
+                err_body = ""
+            logger.error(
+                "Sandbox exec failed: HTTP %s for %s: %s",
+                e.response.status_code,
+                sandbox_name,
+                err_body,
+            )
+            yield f"ERROR: HTTP {e.response.status_code}: {err_body}"
+        except httpx.RequestError as e:
+            logger.error("Sandbox exec request failed for %s: %s", sandbox_name, e)
+            yield f"ERROR: Request failed: {e}"
+
+    async def create_sandbox(self, spec: SandboxCreateRequest) -> SandboxResponse:
+        """Create a sandbox; expects HTTP 201 and a ``SandboxResponse`` in the envelope."""
+        resp = await self._raw_request(
+            span_name="csg-sandbox-create",
+            method="POST",
+            url=self._root(),
+            json_body=_dump_create_body(spec),
+            success_statuses=(201,),
+            timeout=_TIMEOUT,
+            trace_label=spec.sandbox_name,
+        )
+        body = _response_json(resp)
+        parsed = _parse_sandbox_response_json(body)
+        _log_lifecycle_response(
+            span_name="csg-sandbox-create",
+            trace_label=spec.sandbox_name,
+            response=parsed,
+        )
+        return parsed
+
+    async def delete_sandbox(self, sandbox_id: str) -> None:
+        """Tear down resources: alias for :meth:`stop_sandbox` (no HTTP ``DELETE`` on Starhub)."""
+        await self.stop_sandbox(sandbox_id)
+
+    async def upload_files_batch(
+        self,
+        sandbox_name: str,
+        files: list[tuple[str, bytes]],
+        *,
+        timeout: float = 120.0,
+    ) -> dict[str, Any]:
+        """Upload many files in one JSON request (base64 contents) via the gateway proxy."""
+        url = self._upload_files_batch_url(sandbox_name)
+        payload: dict[str, Any] = {
+            "sandbox_name": sandbox_name,
+            "files": [{"path": path, "content": base64.b64encode(content).decode("ascii")} for path, content in files],
+        }
+        resp = await self._raw_request(
+            span_name="csg-sandbox-upload-files-batch",
+            method="POST",
+            url=url,
+            json_body=payload,
+            success_statuses=(200,),
+            timeout=timeout,
+            trace_label=sandbox_name,
+        )
+        return _response_json(resp)
+
+    async def download_files_batch(
+        self,
+        sandbox_name: str,
+        paths: list[str],
+        *,
+        timeout: float = 120.0,
+    ) -> dict[str, Any]:
+        """Download many paths in one JSON request; response shape is server-defined (dict)."""
+        url = self._download_files_batch_url(sandbox_name)
+        payload: dict[str, Any] = {
+            "sandbox_name": sandbox_name,
+            "files": [{"path": p} for p in paths],
+        }
+        resp = await self._raw_request(
+            span_name="csg-sandbox-download-files-batch",
+            method="POST",
+            url=url,
+            json_body=payload,
+            success_statuses=(200,),
+            timeout=timeout,
+            trace_label=sandbox_name,
+        )
+        return _response_json(resp)
+
+    async def upload_file(
+        self,
+        sandbox_name: str,
+        file_name: str,
+        file_bytes: bytes,
+        *,
+        timeout: float = _TIMEOUT,
+    ) -> SandboxUploadFileResponse:
+        """Upload a single file via ``multipart/form-data`` field ``file`` (not JSON)."""
+        url = self._upload_url(sandbox_name)
+        logger.info("[CsgHubSandbox] csg-sandbox-upload-file trace=%s", sandbox_name)
+        try:
+            async with httpx.AsyncClient(trust_env=False, timeout=timeout) as client:
+                resp = await client.post(
+                    url,
+                    headers=self._auth_headers(),
+                    files={"file": (file_name, file_bytes)},
+                )
+                if resp.status_code != 200:
+                    detail = _log_error_body(resp.text)
+                    logger.error(
+                        "[CsgHubSandbox] csg-sandbox-upload-file HTTP error: %s url=%s body=%s",
+                        resp.status_code,
+                        url.split("?", 1)[0],
+                        detail[:2000],
+                    )
+                    raise SandboxHttpError(
+                        f"HTTP {resp.status_code}: {detail}",
+                        status_code=resp.status_code,
+                        request_url=str(resp.request.url),
+                        detail=detail,
+                    )
+                try:
+                    data = resp.json()
+                except json.JSONDecodeError as e:
+                    raise SandboxResponseParseError(f"upload response is not valid JSON: {e}") from e
+                try:
+                    return SandboxUploadFileResponse.model_validate(data)
+                except ValidationError as e:
+                    raise SandboxResponseParseError(str(e), detail=str(e)) from e
+        except SandboxHttpError:
+            raise
+        except SandboxResponseParseError:
+            raise
+        except httpx.RequestError as e:
+            logger.error("[CsgHubSandbox] csg-sandbox-upload-file request failed: %s", e)
+            raise _transport_error(e) from e
+
+    async def get_sandbox_runtime_health(
+        self,
+        sandbox_name: str,
+        *,
+        timeout: float = _TIMEOUT,
+    ) -> None:
+        """GET the sandbox-runtime root through the gateway (readiness probe; follows redirects)."""
+        await self._raw_request(
+            span_name="csg-sandbox-runtime-health",
+            method="GET",
+            url=self._runtime_health_url(sandbox_name),
+            json_body=None,
+            success_statuses=(200,),
+            timeout=timeout,
+            trace_label=sandbox_name,
+            follow_redirects=True,
+        )
+
+    async def get_sandbox(self, sandbox_id: str) -> SandboxResponse:
+        """Return current spec and state for ``GET /api/v1/sandboxes/{sandbox_id}``."""
+        resp = await self._raw_request(
+            span_name="csg-sandbox-get",
+            method="GET",
+            url=f"{self._root()}/{sandbox_id}",
+            json_body=None,
+            success_statuses=(200,),
+            timeout=_TIMEOUT,
+            trace_label=sandbox_id,
+        )
+        body = _response_json(resp)
+        parsed = _parse_sandbox_response_json(body)
+        _log_lifecycle_response(
+            span_name="csg-sandbox-get",
+            trace_label=sandbox_id,
+            response=parsed,
+        )
+        return parsed
+
+    async def update_sandbox_config(self, sandbox_id: str, body: SandboxUpdateConfigRequest) -> SandboxResponse:
+        """Patch mutable fields (image, env, volumes, port, timeout) for an existing sandbox."""
+        resp = await self._raw_request(
+            span_name="csg-sandbox-update-config",
+            method="PATCH",
+            url=f"{self._root()}/{sandbox_id}",
+            json_body=_dump_update_config_body(body),
+            success_statuses=(200,),
+            timeout=_TIMEOUT,
+            trace_label=sandbox_id,
+        )
+        parsed = _parse_sandbox_response_json(_response_json(resp))
+        _log_lifecycle_response(
+            span_name="csg-sandbox-update-config",
+            trace_label=sandbox_id,
+            response=parsed,
+        )
+        return parsed
+
+    async def apply_sandbox(self, spec: SandboxCreateRequest) -> SandboxResponse:
+        """Declarative update: maps :class:`SandboxCreateRequest` into a PATCH by ``sandbox_name``."""
+        update = SandboxUpdateConfigRequest(
+            resource_id=spec.resource_id,
+            image=spec.image,
+            environments=spec.environments,
+            volumes=list(spec.volumes),
+            port=spec.port,
+            timeout=spec.timeout,
+        )
+        return await self.update_sandbox_config(spec.sandbox_name, update)
+
+    async def start_sandbox(self, sandbox_id: str) -> SandboxResponse:
+        """Start workload: ``PUT .../sandboxes/{id}/status/start``."""
+        resp = await self._raw_request(
+            span_name="csg-sandbox-start",
+            method="PUT",
+            url=f"{self._root()}/{sandbox_id}/status/start",
+            json_body=None,
+            success_statuses=(200,),
+            timeout=_TIMEOUT,
+            trace_label=sandbox_id,
+        )
+        parsed = _parse_sandbox_response_json(_response_json(resp))
+        _log_lifecycle_response(
+            span_name="csg-sandbox-start",
+            trace_label=sandbox_id,
+            response=parsed,
+        )
+        return parsed
+
+    async def stop_sandbox(self, sandbox_id: str) -> None:
+        """Stop workload: ``PUT .../sandboxes/{id}/status/stop`` (primary teardown hook)."""
+        await self._raw_request(
+            span_name="csg-sandbox-stop",
+            method="PUT",
+            url=f"{self._root()}/{sandbox_id}/status/stop",
+            json_body=None,
+            success_statuses=(200,),
+            timeout=_TIMEOUT,
+            trace_label=sandbox_id,
+        )
+        logger.info("[CsgHubSandbox] csg-sandbox-stop response trace=%s", sandbox_id)
+
+    async def _raw_request(
+        self,
+        span_name: str,
+        method: str,
+        url: str,
+        json_body: Optional[Dict[str, Any]],
+        success_statuses: tuple[int, ...],
+        timeout: float,
+        trace_label: str,
+        *,
+        follow_redirects: bool = False,
+    ) -> httpx.Response:
+        """Internal JSON request helper: validates status, maps errors to SDK exceptions."""
+        log_url = url.split("?", 1)[0]
+        logger.info("[CsgHubSandbox] %s trace=%s url=%s", span_name, trace_label, log_url)
+        try:
+            async with httpx.AsyncClient(trust_env=False, timeout=timeout) as client:
+                resp = await client.request(
+                    method,
+                    url,
+                    headers=self._headers(),
+                    json=json_body,
+                    follow_redirects=follow_redirects,
+                )
+
+                if resp.status_code not in success_statuses:
+                    detail = _log_error_body(resp.text)
+                    logger.error(
+                        "[CsgHubSandbox] %s HTTP %s trace=%s url=%s response_body=%s",
+                        span_name,
+                        resp.status_code,
+                        trace_label,
+                        log_url,
+                        detail[:2000],
+                    )
+                    resp.raise_for_status()
+
+                return resp
+
+        except httpx.HTTPStatusError as e:
+            detail = _log_error_body(e.response.text)
+            raise SandboxHttpError(
+                f"HTTP {e.response.status_code}: {detail}",
+                status_code=e.response.status_code,
+                request_url=str(e.request.url),
+                detail=detail,
+            ) from e
+
+        except httpx.RequestError as e:
+            logger.error("[CsgHubSandbox] %s request failed: %s", span_name, e)
+            raise _transport_error(e) from e
+
+
+def _response_json(resp: httpx.Response) -> Any:
+    """Parse JSON body or raise :class:`~pycsghub.errors.SandboxResponseParseError`."""
+    try:
+        return resp.json()
+    except json.JSONDecodeError as e:
+        raise SandboxResponseParseError(f"response body is not valid JSON: {e}") from e

--- a/pycsghub/sandbox_client/client.py
+++ b/pycsghub/sandbox_client/client.py
@@ -485,8 +485,7 @@ class CsgHubSandbox:
         follow_redirects: bool = False,
     ) -> httpx.Response:
         """Internal JSON request helper: validates status, maps errors to SDK exceptions."""
-        log_url = url.split("?", 1)[0]
-        logger.info("[CsgHubSandbox] %s trace=%s url=%s", span_name, trace_label, log_url)
+        logger.info("[CsgHubSandbox] %s trace=%s url=%s", span_name, trace_label, url)
         try:
             async with httpx.AsyncClient(trust_env=False, timeout=timeout) as client:
                 resp = await client.request(
@@ -504,7 +503,7 @@ class CsgHubSandbox:
                         span_name,
                         resp.status_code,
                         trace_label,
-                        log_url,
+                        url,
                         detail[:2000],
                     )
                     resp.raise_for_status()

--- a/pycsghub/sandbox_client/config.py
+++ b/pycsghub/sandbox_client/config.py
@@ -1,0 +1,39 @@
+"""Configuration for :class:`~pycsghub.sandbox_client.client.CsgHubSandbox`.
+
+Defaults target the public CSGHub Hub domain from :mod:`pycsghub.constants`. Override ``base_url``
+for self-hosted deployments; set ``aigateway_url`` when sandbox *runtime* routes (streaming
+execute, upload, health) are exposed on a different host than the EE lifecycle API.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pycsghub.constants import DEFAULT_CSGHUB_DOMAIN
+
+
+class CsgHubSandboxConfig(BaseModel):
+    """Endpoints for sandbox lifecycle (Starhub EE/SaaS) vs. runtime proxy (AI Gateway).
+
+    * **Lifecycle** — JSON APIs under ``{base_url}/api/v1/sandboxes``.
+    * **Runtime** — ``{aigateway_url}/v1/sandboxes/...`` (execute, upload, batch files). If
+      ``aigateway_url`` is empty, runtime calls use ``base_url`` (single-host setups).
+
+    Field aliases (``base-url``, ``aigateway-url``) match TOML-style configuration used elsewhere.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    base_url: str = Field(
+        default=DEFAULT_CSGHUB_DOMAIN,
+        alias="base-url",
+        description="Hub / Starhub origin for /api/v1/sandboxes (create, get, patch, start, stop).",
+    )
+    aigateway_url: str = Field(
+        default="",
+        alias="aigateway-url",
+        description=(
+            "Base URL for sandbox-runtime routes proxied as /v1/sandboxes/... "
+            "(execute, upload, batch). Empty string means use base_url."
+        ),
+    )

--- a/pycsghub/sandbox_client/models.py
+++ b/pycsghub/sandbox_client/models.py
@@ -1,0 +1,143 @@
+"""Pydantic models for CSGHub sandbox REST payloads.
+
+Shapes mirror the Go ``types`` package in Starhub (create/update requests, ``SandboxResponse``,
+error bodies). Use these models with :class:`~pycsghub.sandbox_client.client.CsgHubSandbox` to
+serialize requests and validate responses. Extra JSON keys are ignored where the server may evolve
+without a breaking SDK release (``extra="ignore"`` on read models).
+"""
+
+from __future__ import annotations
+
+import datetime  # noqa: TC003
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RunnerVolumeSpec(BaseModel):
+    """PVC subpath and mount path inside the sandbox workload (Go ``types.SandboxVolume``)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    sandbox_mount_subpath: str
+    sandbox_mount_path: str
+    read_only: bool = False
+
+
+# Public alias matching Starhub / API naming ("SandboxVolume").
+SandboxVolume = RunnerVolumeSpec
+
+
+class SandboxCreateRequest(BaseModel):
+    """Request body for ``POST /api/v1/sandboxes`` (Go ``types.SandboxCreateRequest``).
+
+    The server-side UUID field is not part of the JSON wire format (``json:"-"`` in Go).
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    image: str
+    cluster_id: str = Field(
+        default="",
+        description="Kubernetes cluster id; empty when omitted in incoming JSON.",
+    )
+    resource_id: int = Field(
+        default=77,
+        description="Resource pool id; defaults to 77 when omitted in JSON.",
+    )
+    sandbox_name: str
+    environments: dict[str, str] = Field(default_factory=dict)
+    volumes: list[RunnerVolumeSpec] = Field(default_factory=list)
+    port: int = Field(default=18789)
+    timeout: int = Field(default=0)
+
+
+class SandboxCreateResponse(BaseModel):
+    """Spec snapshot embedded in :class:`SandboxResponse` (Go ``types.SandboxCreateResponse``)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    sandbox_name: str
+    image: str
+    environments: dict[str, str] = Field(default_factory=dict)
+    volumes: list[RunnerVolumeSpec] = Field(default_factory=list)
+    port: int = Field(default=18789)
+
+
+class SandboxState(BaseModel):
+    """Runtime status for a sandbox (Go ``types.SandboxState``).
+
+    ``exited_code`` defaults to ``0`` when the backend omits it (older responses).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    status: str
+    exited_code: int = 0
+    created_at: datetime.datetime
+    started_at: Optional[datetime.datetime] = None
+    timeout: int = Field(default=0)
+
+
+class SandboxUpdateConfigRequest(BaseModel):
+    """Request body for ``PATCH /api/v1/sandboxes/{id}`` (Go ``types.SandboxUpdateConfigRequest``).
+
+    Server UUID is not serialized; the client omits default-empty fields to mirror Go ``omitempty``.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    resource_id: int
+    image: str
+    environments: dict[str, str] = Field(default_factory=dict)
+    volumes: list[RunnerVolumeSpec] = Field(default_factory=list)
+    port: int = Field(default=18789)
+    timeout: int = Field(
+        default=0,
+        description="EE sandbox reclaim/idle timeout in seconds (align with SandboxCreateRequest.timeout).",
+    )
+
+
+class SandboxResponse(BaseModel):
+    """Envelope returned by lifecycle APIs (Go ``types.SandboxResponse``).
+
+    The nested ``Create`` field is server-internal and not present on the wire (``json:"-"`` in Go).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    spec: SandboxCreateResponse
+    state: SandboxState
+
+
+class SandboxErrorResponse(BaseModel):
+    """Error JSON from Starhub or gateways (union of ``message``, ``msg``, ``error`` shapes)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    code: Optional[int] = None
+    message: Optional[str] = None
+    error: Optional[str] = None
+    msg: Optional[str] = None
+
+    def log_line(self) -> str:
+        """Human-readable single line for logs (prefers ``error``, then ``message`` / ``msg``)."""
+        if self.error:
+            return self.error
+        if self.message:
+            if self.code is not None:
+                return f"{self.code}: {self.message}"
+            return self.message
+        if self.msg:
+            if self.code is not None:
+                return f"{self.code}: {self.msg}"
+            return self.msg
+        return "unknown error"
+
+
+class SandboxUploadFileResponse(BaseModel):
+    """JSON body from ``POST .../v1/sandboxes/{name}/upload`` (multipart upload via gateway)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    message: str

--- a/pycsghub/sandbox_client/models.py
+++ b/pycsghub/sandbox_client/models.py
@@ -48,7 +48,10 @@ class SandboxCreateRequest(BaseModel):
     sandbox_name: str
     environments: dict[str, str] = Field(default_factory=dict)
     volumes: list[RunnerVolumeSpec] = Field(default_factory=list)
-    port: int = Field(default=18789)
+    port: int = Field(
+        default=0,
+        description="Service port; 0 means let the server choose a default.",
+    )
     timeout: int = Field(default=0)
 
 
@@ -61,7 +64,7 @@ class SandboxCreateResponse(BaseModel):
     image: str
     environments: dict[str, str] = Field(default_factory=dict)
     volumes: list[RunnerVolumeSpec] = Field(default_factory=list)
-    port: int = Field(default=18789)
+    port: int = Field(default=0)
 
 
 class SandboxState(BaseModel):
@@ -91,7 +94,10 @@ class SandboxUpdateConfigRequest(BaseModel):
     image: str
     environments: dict[str, str] = Field(default_factory=dict)
     volumes: list[RunnerVolumeSpec] = Field(default_factory=list)
-    port: int = Field(default=18789)
+    port: int = Field(
+        default=0,
+        description="Service port; 0 means let the server choose a default.",
+    )
     timeout: int = Field(
         default=0,
         description="EE sandbox reclaim/idle timeout in seconds (align with SandboxCreateRequest.timeout).",

--- a/pycsghub/test/sandbox_client/__init__.py
+++ b/pycsghub/test/sandbox_client/__init__.py
@@ -1,0 +1,1 @@
+# Sandbox client tests

--- a/pycsghub/test/sandbox_client/conftest.py
+++ b/pycsghub/test/sandbox_client/conftest.py
@@ -1,0 +1,89 @@
+"""Shared fixtures for sandbox_client tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any, Optional
+
+import httpx
+import pytest
+
+from pycsghub.sandbox_client.config import CsgHubSandboxConfig
+
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+def run_async(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def csghub_sandbox_cfg_minimal() -> CsgHubSandboxConfig:
+    return CsgHubSandboxConfig.model_construct(
+        base_url="http://sandbox-api.test",
+        aigateway_url="",
+    )
+
+
+def _minimal_state() -> dict[str, Any]:
+    return {
+        "status": "Running",
+        "exited_code": 0,
+        "created_at": "2024-01-01T00:00:00Z",
+        "started_at": "2024-01-01T00:00:01Z",
+    }
+
+
+def sample_sandbox_response(
+    *,
+    sandbox_name: str = "sandbox-user-abc",
+) -> dict[str, Any]:
+    return {
+        "spec": {
+            "image": "sandbox:test",
+            "sandbox_name": sandbox_name,
+            "environments": {},
+            "volumes": [],
+        },
+        "state": _minimal_state(),
+    }
+
+
+def sample_runner_create_response(*, sandbox_id: str = "sandbox-user-abc") -> dict[str, Any]:
+    return sample_sandbox_response(sandbox_name=sandbox_id)
+
+
+def sample_httpbase_envelope(msg: str, data: Optional[dict[str, Any]]) -> dict[str, Any]:
+    out: dict[str, Any] = {"msg": msg}
+    if data is not None:
+        out["data"] = data
+    return out
+
+
+def sample_sandbox_get_json(*, sandbox_name: str = "test-sb") -> dict[str, Any]:
+    return sample_httpbase_envelope("OK", sample_sandbox_response(sandbox_name=sandbox_name))
+
+
+def sample_v1_patch_success_json(*, sandbox_id: str = "sb-1") -> dict[str, Any]:
+    return sample_httpbase_envelope("OK", sample_sandbox_response(sandbox_name=sandbox_id))
+
+
+def make_mock_transport(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> httpx.MockTransport:
+    return httpx.MockTransport(handler)
+
+
+def patch_async_client_with_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    transport: httpx.MockTransport,
+) -> None:
+    def async_client_factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return _REAL_ASYNC_CLIENT(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "pycsghub.sandbox_client.client.httpx.AsyncClient",
+        async_client_factory,
+    )

--- a/pycsghub/test/sandbox_client/test_client.py
+++ b/pycsghub/test/sandbox_client/test_client.py
@@ -1,0 +1,495 @@
+"""Behavior tests for CsgHubSandbox (HTTP mocked via httpx.MockTransport).
+
+SDK maps HTTP failures to ``SandboxHttpError`` / ``SandboxTransportError`` (not raw httpx).
+Does not cover ``exists`` (not implemented in SDK).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from pycsghub.errors import SandboxHttpError
+from pycsghub.sandbox_client import CsgHubSandboxConfig
+from pycsghub.sandbox_client.client import CsgHubSandbox
+from pycsghub.sandbox_client.models import SandboxCreateRequest, SandboxErrorResponse
+
+from .conftest import (
+    make_mock_transport,
+    patch_async_client_with_transport,
+    run_async,
+    sample_httpbase_envelope,
+    sample_runner_create_response,
+    sample_sandbox_get_json,
+    sample_v1_patch_success_json,
+)
+
+
+class TestCsgHubSandboxCreate:
+    def test_when_api_returns_201_on_post_then_create_returns_id(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "test-bearer-token",
+        )
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            assert request.method == "POST"
+            assert str(request.url) == "http://sandbox-api.test/api/v1/sandboxes"
+            assert request.headers.get("Authorization") == "Bearer test-bearer-token"
+            body = json.loads(request.content)
+            assert body["sandbox_name"] == "sandbox-x"
+            assert body["image"] == "sandbox:test"
+            assert body["resource_id"] == 1001
+            assert body["port"] == 18789
+            return httpx.Response(
+                201,
+                json=sample_httpbase_envelope("Created", sample_runner_create_response(sandbox_id="sandbox-x")),
+            )
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="test-bearer-token")
+        spec = SandboxCreateRequest(
+            image="sandbox:test",
+            resource_id=1001,
+            sandbox_name="sandbox-x",
+        )
+
+        result = run_async(client.create_sandbox(spec))
+
+        assert result.spec.sandbox_name == "sandbox-x"
+        assert result.state.status == "Running"
+        assert len(captured) == 1
+
+    def test_when_explicit_token_then_bearer_uses_it(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.headers.get("Authorization") == "Bearer ctx-hub-jwt"
+            assert request.headers.get("Content-Type") == "application/json"
+            return httpx.Response(
+                201,
+                json=sample_httpbase_envelope("Created", sample_runner_create_response(sandbox_id="sandbox-x")),
+            )
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="ctx-hub-jwt")
+        spec = SandboxCreateRequest(
+            image="sandbox:test",
+            resource_id=1,
+            sandbox_name="n",
+        )
+        run_async(client.create_sandbox(spec))
+
+    def test_when_api_returns_4xx_then_raises_sandbox_http_error(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "t",
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                400,
+                json={"error": "invalid request"},
+            )
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="t")
+        spec = SandboxCreateRequest(
+            image="sandbox:test",
+            resource_id=1,
+            sandbox_name="x",
+        )
+
+        with pytest.raises(SandboxHttpError) as exc_info:
+            run_async(client.create_sandbox(spec))
+        assert exc_info.value.status_code == 400
+
+
+class TestSandboxErrorBodyParsing:
+    def test_when_error_json_uses_msg_then_msg_is_returned(self) -> None:
+        err = SandboxErrorResponse.model_validate_json('{"msg":"sandbox is starting"}')
+        assert err.log_line() == "sandbox is starting"
+
+    def test_when_error_json_has_code_and_msg_then_prefixed_string_is_returned(self) -> None:
+        err = SandboxErrorResponse.model_validate_json('{"code":400,"msg":"sandbox is starting"}')
+        assert err.log_line() == "400: sandbox is starting"
+
+
+class TestSandboxApiV1OtherEndpoints:
+    def test_get_sandbox_uses_doc_path_and_parses_body(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "t",
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "GET"
+            assert str(request.url) == "http://sandbox-api.test/api/v1/sandboxes/sb-a"
+            return httpx.Response(200, json=sample_sandbox_get_json(sandbox_name="sb-a"))
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="t")
+        result = run_async(client.get_sandbox("sb-a"))
+        assert result.spec.sandbox_name == "sb-a"
+        assert result.spec.image == "sandbox:test"
+
+    def test_apply_sandbox_patches_by_name_and_accepts_200(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "t",
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "PATCH"
+            assert str(request.url) == "http://sandbox-api.test/api/v1/sandboxes/sb-b"
+            body = json.loads(request.content)
+            assert "sandbox_name" not in body
+            assert body["resource_id"] == 1001
+            assert body["image"] == "img:latest"
+            assert body["timeout"] == 600
+            return httpx.Response(200, json=sample_v1_patch_success_json(sandbox_id="sb-b"))
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="t")
+        spec = SandboxCreateRequest(
+            image="img:latest",
+            resource_id=1001,
+            sandbox_name="sb-b",
+            timeout=600,
+        )
+        result = run_async(client.apply_sandbox(spec))
+        assert result.spec.sandbox_name == "sb-b"
+        assert result.state.status == "Running"
+
+    def test_start_sandbox_puts_status_start(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "t",
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "PUT"
+            assert str(request.url) == "http://sandbox-api.test/api/v1/sandboxes/sb-s/status/start"
+            return httpx.Response(
+                200,
+                json=sample_httpbase_envelope("OK", sample_runner_create_response(sandbox_id="sb-s")),
+            )
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="t")
+        result = run_async(client.start_sandbox("sb-s"))
+        assert result.spec.sandbox_name == "sb-s"
+
+    def test_stop_sandbox_puts_status_stop(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "t",
+        )
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            assert request.method == "PUT"
+            assert str(request.url) == "http://sandbox-api.test/api/v1/sandboxes/sb-t/status/stop"
+            return httpx.Response(200, json={"msg": "OK"})
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="t")
+        run_async(client.stop_sandbox("sb-t"))
+        assert len(captured) == 1
+
+
+class TestSandboxLifecycleResponseLogging:
+    def test_create_get_start_log_response_summary(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "t",
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "POST" and request.url.path.endswith("/api/v1/sandboxes"):
+                return httpx.Response(
+                    201,
+                    json=sample_httpbase_envelope("Created", sample_runner_create_response(sandbox_id="sb-log")),
+                )
+            if request.method == "GET" and request.url.path.endswith("/api/v1/sandboxes/sb-log"):
+                return httpx.Response(200, json=sample_sandbox_get_json(sandbox_name="sb-log"))
+            if request.method == "PUT" and request.url.path.endswith("/api/v1/sandboxes/sb-log/status/start"):
+                return httpx.Response(
+                    200,
+                    json=sample_httpbase_envelope("OK", sample_runner_create_response(sandbox_id="sb-log")),
+                )
+            return httpx.Response(500, json={"error": "unexpected"})
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        info_mock = MagicMock()
+        monkeypatch.setattr("pycsghub.sandbox_client.client.logger.info", info_mock)
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="t")
+
+        spec = SandboxCreateRequest(image="sandbox:test", resource_id=1, sandbox_name="sb-log")
+        run_async(client.create_sandbox(spec))
+        run_async(client.get_sandbox("sb-log"))
+        run_async(client.start_sandbox("sb-log"))
+
+        all_calls = " ".join(str(call) for call in info_mock.call_args_list)
+        assert "csg-sandbox-create" in all_calls and "response trace" in all_calls
+        assert "csg-sandbox-get" in all_calls
+        assert "csg-sandbox-start" in all_calls
+
+
+class TestCsgHubSandboxStreamExecute:
+    def test_when_stream_returns_lines_then_yields_non_empty_lines(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "test-bearer-token",
+        )
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            assert request.method == "POST"
+            assert str(request.url) == "http://sandbox-api.test/v1/sandboxes/my-sb/execute?port=8888"
+            body = json.loads(request.content)
+            assert body == {"command": "ls -l"}
+            assert request.headers.get("Authorization") == "Bearer test-bearer-token"
+            return httpx.Response(200, content=b"line1\nline2\n")
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="test-bearer-token")
+
+        async def _collect() -> list[str]:
+            out: list[str] = []
+            async for line in client.stream_execute_command("my-sb", "ls -l"):
+                out.append(line)
+            return out
+
+        lines = run_async(_collect())
+        assert lines == ["line1", "line2"]
+        assert len(captured) == 1
+
+    def test_when_aigateway_url_set_then_execute_uses_gateway_host(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "t",
+        )
+        cfg = CsgHubSandboxConfig.model_construct(
+            base_url="http://starhub.test",
+            aigateway_url="http://aigateway.test",
+        )
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            assert str(request.url) == "http://aigateway.test/v1/sandboxes/my-sb/execute?port=8888"
+            return httpx.Response(200, content=b"ok\n")
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=cfg, token="t")
+
+        async def _collect() -> list[str]:
+            return [line async for line in client.stream_execute_command("my-sb", "echo")]
+
+        lines = run_async(_collect())
+        assert lines == ["ok"]
+        assert len(captured) == 1
+
+    def test_when_http_error_then_yields_error_prefix_not_raise(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "t",
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, content=b"bad")
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="t")
+
+        async def _collect() -> list[str]:
+            return [line async for line in client.stream_execute_command("sb", "x")]
+
+        lines = run_async(_collect())
+        assert len(lines) == 1
+        assert lines[0].startswith("ERROR: HTTP 400:")
+
+    def test_when_request_error_then_yields_error_prefix(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "t",
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("no route", request=request)
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="t")
+
+        async def _collect() -> list[str]:
+            return [line async for line in client.stream_execute_command("sb", "x")]
+
+        lines = run_async(_collect())
+        assert len(lines) == 1
+        assert lines[0].startswith("ERROR: Request failed:")
+
+
+class TestCsgHubSandboxFileEndpoints:
+    def test_when_upload_file_then_posts_multipart_and_parses_message(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "test-bearer-token",
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert str(request.url) == "http://sandbox-api.test/v1/sandboxes/sb-up/upload?port=8888"
+            assert request.headers.get("Authorization") == "Bearer test-bearer-token"
+            content_type = request.headers.get("Content-Type", "")
+            assert content_type.startswith("multipart/form-data;")
+            assert b'filename="hello.txt"' in request.content
+            return httpx.Response(200, json={"message": "File 'hello.txt' uploaded successfully."})
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="test-bearer-token")
+
+        result = run_async(
+            client.upload_file(
+                sandbox_name="sb-up",
+                file_name="hello.txt",
+                file_bytes=b"hello world",
+            ),
+        )
+        assert result.message == "File 'hello.txt' uploaded successfully."
+
+
+class TestCsgHubSandboxStopAndBatch:
+    def test_delete_sandbox_calls_put_status_stop(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "test-bearer-token",
+        )
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            if request.method == "PUT" and request.url.path.endswith("/status/stop"):
+                return httpx.Response(200, json={"msg": "OK", "data": None})
+            return httpx.Response(500, json={"error": "unexpected"})
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="test-bearer-token")
+        run_async(client.delete_sandbox("my-sandbox"))
+        assert len(captured) == 1
+        assert captured[0].method == "PUT"
+        assert captured[0].url.path.endswith("/api/v1/sandboxes/my-sandbox/status/stop")
+
+    def test_upload_files_batch_posts_json(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "test-bearer-token",
+        )
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            if request.method == "POST" and "/upload-files" in str(request.url):
+                body = json.loads(request.content.decode())
+                assert body["sandbox_name"] == "sb1"
+                assert body["files"][0]["path"] == "a.txt"
+                assert "content" in body["files"][0]
+                return httpx.Response(200, json={"results": [{"path": "a.txt", "success": True, "error": ""}]})
+            return httpx.Response(500, json={"error": "unexpected"})
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="test-bearer-token")
+        out = run_async(client.upload_files_batch("sb1", [("a.txt", b"hi")]))
+        assert out["results"][0]["success"] is True
+        assert "upload-files" in str(captured[0].url)
+        assert "?port=8888" in str(captured[0].url)
+
+    def test_download_files_batch_posts_json(
+        self,
+        csghub_sandbox_cfg_minimal: CsgHubSandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pycsghub.sandbox_client.client.get_token_to_send",
+            lambda _token=None: "test-bearer-token",
+        )
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            if request.method == "POST" and "/download-files" in str(request.url):
+                return httpx.Response(
+                    200,
+                    json={"results": [{"path": "a.txt", "content": "aGk=", "success": True, "error": ""}]},
+                )
+            return httpx.Response(500, json={"error": "unexpected"})
+
+        patch_async_client_with_transport(monkeypatch, make_mock_transport(handler))
+        client = CsgHubSandbox(csghub_sandbox_cfg=csghub_sandbox_cfg_minimal, token="test-bearer-token")
+        out = run_async(client.download_files_batch("sb1", ["a.txt"]))
+        assert out["results"][0]["success"] is True
+        assert "download-files" in str(captured[0].url)

--- a/pycsghub/test/sandbox_client/test_client.py
+++ b/pycsghub/test/sandbox_client/test_client.py
@@ -49,7 +49,7 @@ class TestCsgHubSandboxCreate:
             assert body["sandbox_name"] == "sandbox-x"
             assert body["image"] == "sandbox:test"
             assert body["resource_id"] == 1001
-            assert body["port"] == 18789
+            assert body["port"] == 0
             return httpx.Response(
                 201,
                 json=sample_httpbase_envelope("Created", sample_runner_create_response(sandbox_id="sandbox-x")),

--- a/pycsghub/test/sandbox_client/test_models.py
+++ b/pycsghub/test/sandbox_client/test_models.py
@@ -1,0 +1,139 @@
+"""Tests for sandbox Pydantic models (no mocks).
+
+SDK does not ship ``SandboxPathExistsResponse`` / ``exists`` API (see package docs).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from pycsghub.sandbox_client.models import (
+    RunnerVolumeSpec,
+    SandboxCreateRequest,
+    SandboxCreateResponse,
+    SandboxResponse,
+    SandboxState,
+    SandboxUpdateConfigRequest,
+)
+
+
+class TestSandboxCreateRequest:
+    def test_when_json_matches_api_then_fields_round_trip(self) -> None:
+        raw = {
+            "image": "x:y",
+            "resource_id": 42,
+            "sandbox_name": "sn-1",
+            "environments": {"A": "b"},
+            "volumes": [
+                {
+                    "sandbox_mount_subpath": "sub",
+                    "sandbox_mount_path": "/w",
+                    "read_only": False,
+                },
+            ],
+        }
+        spec = SandboxCreateRequest.model_validate(raw)
+
+        assert spec.resource_id == 42
+        assert spec.sandbox_name == "sn-1"
+        assert spec.environments == {"A": "b"}
+        assert spec.volumes[0].sandbox_mount_subpath == "sub"
+
+    def test_when_resource_id_omitted_then_defaults_to_77(self) -> None:
+        raw = {"image": "x:y", "sandbox_name": "sn-2"}
+        spec = SandboxCreateRequest.model_validate(raw)
+        assert spec.resource_id == 77
+        data = spec.model_dump(mode="json", exclude_none=True, by_alias=True)
+        assert data["resource_id"] == 77
+        assert data["sandbox_name"] == "sn-2"
+
+    def test_when_dumped_then_volume_keys_match_sandbox_volume_json(self) -> None:
+        spec = SandboxCreateRequest(
+            image="x:y",
+            resource_id=1,
+            sandbox_name="s1",
+            volumes=[
+                RunnerVolumeSpec(
+                    sandbox_mount_subpath="pvc-sub",
+                    sandbox_mount_path="/work",
+                    read_only=True,
+                ),
+            ],
+        )
+        data = spec.model_dump(mode="json", exclude_none=True, by_alias=True)
+        assert data["volumes"][0] == {
+            "sandbox_mount_subpath": "pvc-sub",
+            "sandbox_mount_path": "/work",
+            "read_only": True,
+        }
+
+
+class TestSandboxUpdateConfigRequest:
+    def test_when_dumped_then_image_is_required(self) -> None:
+        req = SandboxUpdateConfigRequest(resource_id=1, image="img:v1", environments={"K": "v"})
+        data = req.model_dump(mode="json", exclude_none=True, exclude_defaults=True, by_alias=True)
+        assert data == {"resource_id": 1, "image": "img:v1", "environments": {"K": "v"}}
+
+    def test_when_image_missing_then_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            SandboxUpdateConfigRequest.model_validate({"resource_id": 1})
+
+
+class TestSandboxResponse:
+    def test_when_json_matches_types_sandbox_response_then_spec_and_state_parse(self) -> None:
+        raw = {
+            "spec": {
+                "image": "img:latest",
+                "sandbox_name": "sb-1",
+                "environments": {},
+                "volumes": [],
+            },
+            "state": {
+                "status": "Running",
+                "exited_code": 0,
+                "created_at": "2024-06-01T12:00:00Z",
+            },
+        }
+        resp = SandboxResponse.model_validate(raw)
+
+        assert resp.spec.sandbox_name == "sb-1"
+        assert resp.spec.image == "img:latest"
+        assert resp.spec.port == 18789
+        assert resp.state.status == "Running"
+        assert resp.state.exited_code == 0
+
+
+class TestSandboxCreateResponse:
+    def test_when_json_matches_then_fields_parse(self) -> None:
+        raw = {
+            "sandbox_name": "sb-2",
+            "image": "img:v2",
+            "environments": {"A": "b"},
+            "volumes": [],
+        }
+        spec = SandboxCreateResponse.model_validate(raw)
+        assert spec.sandbox_name == "sb-2"
+        assert spec.image == "img:v2"
+        assert spec.port == 18789
+
+    def test_when_spec_includes_port_then_parsed(self) -> None:
+        raw = {
+            "sandbox_name": "sb-3",
+            "image": "img:v3",
+            "environments": {},
+            "volumes": [],
+            "port": 9000,
+        }
+        spec = SandboxCreateResponse.model_validate(raw)
+        assert spec.port == 9000
+
+
+class TestSandboxState:
+    def test_started_at_optional(self) -> None:
+        s = SandboxState(
+            status="Pending",
+            exited_code=-1,
+            created_at="2024-01-01T00:00:00Z",
+        )
+        assert s.started_at is None

--- a/pycsghub/test/sandbox_client/test_models.py
+++ b/pycsghub/test/sandbox_client/test_models.py
@@ -44,9 +44,11 @@ class TestSandboxCreateRequest:
         raw = {"image": "x:y", "sandbox_name": "sn-2"}
         spec = SandboxCreateRequest.model_validate(raw)
         assert spec.resource_id == 77
+        assert spec.port == 0
         data = spec.model_dump(mode="json", exclude_none=True, by_alias=True)
         assert data["resource_id"] == 77
         assert data["sandbox_name"] == "sn-2"
+        assert data["port"] == 0
 
     def test_when_dumped_then_volume_keys_match_sandbox_volume_json(self) -> None:
         spec = SandboxCreateRequest(
@@ -99,7 +101,7 @@ class TestSandboxResponse:
 
         assert resp.spec.sandbox_name == "sb-1"
         assert resp.spec.image == "img:latest"
-        assert resp.spec.port == 18789
+        assert resp.spec.port == 0
         assert resp.state.status == "Running"
         assert resp.state.exited_code == 0
 
@@ -115,7 +117,7 @@ class TestSandboxCreateResponse:
         spec = SandboxCreateResponse.model_validate(raw)
         assert spec.sandbox_name == "sb-2"
         assert spec.image == "img:v2"
-        assert spec.port == 18789
+        assert spec.port == 0
 
     def test_when_spec_includes_port_then_parsed(self) -> None:
         raw = {

--- a/pycsghub/test/test_sandbox_cli.py
+++ b/pycsghub/test/test_sandbox_cli.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from pycsghub.cmd import sandbox as sandbox_cmd
 from pycsghub.constants import DEFAULT_CSGHUB_DOMAIN
-from pycsghub.sandbox_client.models import SandboxCreateRequest, SandboxResponse
+from pycsghub.sandbox_client.models import SandboxCreateRequest, SandboxResponse, SandboxUploadFileResponse
 
 
 class TestSandboxCliHelpers(unittest.TestCase):
@@ -115,6 +115,73 @@ class TestSandboxCliCreateMocked(unittest.TestCase):
         with self.assertRaises(SystemExit) as ctx:
             sandbox_cmd.run_lifecycle(boom())
         self.assertEqual(ctx.exception.code, 1)
+
+
+class TestSandboxUploadMocked(unittest.TestCase):
+    def test_upload_calls_client_and_prints_json(self) -> None:
+        sample = SandboxUploadFileResponse(message="uploaded")
+        with tempfile.TemporaryDirectory() as tmp:
+            file_path = Path(tmp) / "demo.txt"
+            file_path.write_text("hello", encoding="utf-8")
+            with patch("pycsghub.cmd.sandbox.CsgHubSandbox") as mock_cls:
+                instance = MagicMock()
+                instance.upload_file = AsyncMock(return_value=sample)
+                mock_cls.return_value = instance
+                with patch("builtins.print") as mock_print:
+                    sandbox_cmd.upload(
+                        sandbox_name="sb1",
+                        local_path=str(file_path),
+                        token="t",
+                        endpoint="https://hub.example.com",
+                        aigateway_url="",
+                        timeout=10.0,
+                    )
+                mock_print.assert_called_once()
+                payload = json.loads(mock_print.call_args[0][0])
+                self.assertEqual(payload["message"], "uploaded")
+
+    def test_upload_missing_file_exits(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            sandbox_cmd.upload(
+                sandbox_name="sb1",
+                local_path="/tmp/does-not-exist-12345",
+                token=None,
+                endpoint=None,
+                aigateway_url=None,
+                timeout=10.0,
+            )
+        self.assertEqual(ctx.exception.code, 1)
+
+
+class TestSandboxTyperIntegration(unittest.TestCase):
+    def test_sandbox_get_help(self) -> None:
+        from pycsghub.cli import app
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["sandbox", "get", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Get sandbox status", result.stdout)
+
+    def test_sandbox_upload_wires_arguments(self) -> None:
+        from pycsghub.cli import app
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        with patch("pycsghub.cli.sandbox.upload") as mock_upload:
+            result = runner.invoke(
+                app,
+                ["sandbox", "upload", "sb1", "/tmp/demo.txt", "--timeout", "8.5"],
+            )
+        self.assertEqual(result.exit_code, 0)
+        mock_upload.assert_called_once_with(
+            sandbox_name="sb1",
+            local_path="/tmp/demo.txt",
+            token=None,
+            endpoint=DEFAULT_CSGHUB_DOMAIN,
+            aigateway_url=None,
+            timeout=8.5,
+        )
 
 
 if __name__ == "__main__":

--- a/pycsghub/test/test_sandbox_cli.py
+++ b/pycsghub/test/test_sandbox_cli.py
@@ -1,0 +1,121 @@
+"""Tests for pycsghub.cmd.sandbox helpers (no network)."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pycsghub.cmd import sandbox as sandbox_cmd
+from pycsghub.constants import DEFAULT_CSGHUB_DOMAIN
+from pycsghub.sandbox_client.models import SandboxCreateRequest, SandboxResponse
+
+
+class TestSandboxCliHelpers(unittest.TestCase):
+    def test_parse_env_pairs_parses_and_rejects(self) -> None:
+        self.assertEqual(
+            sandbox_cmd.parse_env_pairs(["A=1", "B=two=2"]),
+            {"A": "1", "B": "two=2"},
+        )
+        with self.assertRaises(ValueError):
+            sandbox_cmd.parse_env_pairs(["no-equals"])
+
+    def test_sandbox_config_defaults(self) -> None:
+        cfg = sandbox_cmd.sandbox_config(None, None)
+        self.assertEqual(cfg.base_url, DEFAULT_CSGHUB_DOMAIN)
+        self.assertEqual(cfg.aigateway_url, "")
+
+    def test_load_create_spec_roundtrip(self) -> None:
+        spec = SandboxCreateRequest(
+            image="img:tag",
+            sandbox_name="sn1",
+            cluster_id="c1",
+            resource_id=1,
+            environments={"K": "V"},
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "spec.json"
+            path.write_text(spec.model_dump_json(), encoding="utf-8")
+            loaded = sandbox_cmd.load_create_spec(str(path))
+        self.assertEqual(loaded.sandbox_name, "sn1")
+        self.assertEqual(loaded.image, "img:tag")
+
+    def test_create_requires_image_or_spec(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            sandbox_cmd.create(
+                token=None,
+                endpoint=None,
+                aigateway_url=None,
+                image=None,
+                name=None,
+                cluster_id="",
+                resource_id=77,
+                port=0,
+                timeout=0,
+                env=None,
+                spec_path=None,
+            )
+        self.assertEqual(ctx.exception.code, 1)
+
+
+class TestSandboxCliCreateMocked(unittest.TestCase):
+    def test_create_calls_client_and_prints_json(self) -> None:
+        sample = SandboxResponse.model_validate(
+            {
+                "spec": {
+                    "sandbox_name": "x",
+                    "image": "i",
+                    "environments": {},
+                    "volumes": [],
+                    "port": 0,
+                },
+                "state": {
+                    "status": "Running",
+                    "exited_code": 0,
+                    "created_at": "2020-01-01T00:00:00Z",
+                    "timeout": 0,
+                },
+            },
+        )
+
+        with patch("pycsghub.cmd.sandbox.CsgHubSandbox") as mock_cls:
+            instance = MagicMock()
+            instance.create_sandbox = AsyncMock(return_value=sample)
+            mock_cls.return_value = instance
+            with patch("builtins.print") as mock_print:
+                sandbox_cmd.create(
+                    token="t",
+                    endpoint="https://hub.example.com",
+                    aigateway_url="",
+                    image="img:1",
+                    name="sb1",
+                    cluster_id="",
+                    resource_id=77,
+                    port=0,
+                    timeout=0,
+                    env=["E=1"],
+                    spec_path=None,
+                )
+            mock_print.assert_called_once()
+            out = mock_print.call_args[0][0]
+            data = json.loads(out)
+            self.assertEqual(data["spec"]["sandbox_name"], "x")
+
+    def test_run_lifecycle_maps_sdk_error_to_exit(self) -> None:
+        from pycsghub.errors import SandboxHttpError
+
+        async def boom() -> None:
+            raise SandboxHttpError(
+                "fail",
+                status_code=400,
+                request_url="http://u",
+                detail="bad",
+            )
+
+        with self.assertRaises(SystemExit) as ctx:
+            sandbox_cmd.run_lifecycle(boom())
+        self.assertEqual(ctx.exception.code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     "typing-extensions",
     "huggingface_hub>=1.2.0",
     "python-dotenv",
+    "httpx",
+    "pydantic>=2",
 ]
 
 [project.optional-dependencies]
@@ -45,6 +47,7 @@ train = [
 dev = [
     "ruff>=0.4.0",
     "build>=1.0.0",
+    "pytest>=8.0.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "csghub-sdk"
-version = "0.8.4"
+version = "0.9.0"
 description = "CSGHub SDK for downloading and uploading models, datasets, and spaces"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary

This PR adds `pycsghub.sandbox_client`, an async HTTP client for CSGHub sandbox lifecycle APIs (`/api/v1/sandboxes`) and runtime endpoints (`/v1/sandboxes/...` via optional `aigateway_url`).

## Author contact

- **Email:** [wh.ji@opencsg.com](mailto:wh.ji@opencsg.com)
- **Affiliation:** OpenCSG (organization member; use this address for maintainer / org verification if needed)

## Changes

- **Client**: `CsgHubSandbox` — create/get/update, start/stop, stream command execution, single upload, batch upload/download, runtime health.
- **Errors**: `SandboxHttpError`, `SandboxTransportError`, `SandboxResponseParseError` (and base `SandboxError`) in `pycsghub/errors.py`.
- **Config**: `CsgHubSandboxConfig` with `base_url` / `aigateway_url` (empty `aigateway_url` falls back to `base_url` for runtime routes).
- **Dependencies**: `httpx`, `pydantic>=2`; **dev**: `pytest>=8` for tests under `pycsghub/test/sandbox_client/`.
- **Docs**: English and Chinese SDK docs (`doc/sdk.md`, `doc/sdk_cn.md`).

## How to test

```bash
uv pip install -e ".[dev]"   # or pip install -e ".[dev]"
pytest pycsghub/test/sandbox_client/ -q
```
