### PR TITLE
Fix 'Invalid port' error on Windows by using forward slash for URL construction

### DIFF
--- a/pycsghub/utils.py
+++ b/pycsghub/utils.py
@@ -545,7 +545,8 @@ def get_endpoint(endpoint: Optional[str] = None, operation: Optional[str] = OPER
 
 
 def get_xnet_endpoint(endpoint: str) -> str:
-    return os.path.join(endpoint, XNET_API_PATH)
+    # Use forward slash for URLs instead of os.path.join which uses backslash on Windows
+    return f"{endpoint.rstrip('/')}/{XNET_API_PATH}"
 
 def disable_xnet() -> bool:
     """Check if xnet is disabled.


### PR DESCRIPTION
This PR fixes the 'Invalid port' error encountered on Windows when using the `csghub-cli download` command.

### Description
The issue was caused by using `os.path.join(endpoint, XNET_API_PATH)` to construct the XNet endpoint URL. On Windows, `os.path.join` uses a backslash `\` as a separator, which is invalid for URLs and lead to errors like `Invalid port: '55363\\hf'`.

### Changes
- Replaced `os.path.join` with a URL-safe implementation using a forward slash `/` in `pycsghub/utils.py`.
- Ensured trailing slashes are handled correctly by using `.rstrip('/')`.

Fixes #127 
