### PR TITLE
fix: prevent HuggingFace implicit token fallback in CsgXnetApi (Issue #129)

### DIFF
--- a/pycsghub/api_client/api_client_xet.py
+++ b/pycsghub/api_client/api_client_xet.py
@@ -16,7 +16,12 @@ class CsgXnetApi(HfApi):
         cache_dir = get_cache_dir()
         os.environ["HF_HUB_CACHE"] = cache_dir
         
-        self._token = token
+        # Convert None to False to prevent HuggingFace's implicit token fallback.
+        # In HF's semantics, token=None means "use cached token" (falls back to
+        # HF_TOKEN env or ~/.cache/huggingface/token), while token=False means
+        # "explicitly do NOT send any auth token". When CSGHub has no token,
+        # we must use False to avoid sending an unrelated HF token to CSGHub.
+        self._token = token if token is not None else False
         self._endpoint = endpoint
         self._user_name = user_name
         self._cache_dir = cache_dir
@@ -51,7 +56,7 @@ class CsgXnetApi(HfApi):
         # Note: calling super().__init__ (HfApi) might use the default HF_ENDPOINT from huggingface_hub.constants
         # if it was imported before we set os.environ["HF_ENDPOINT"].
         # Explicitly passing endpoint ensures the instance uses our custom endpoint.
-        super().__init__(endpoint=endpoint, token=token)
+        super().__init__(endpoint=endpoint, token=self._token)
         
         # Also ensure instance .endpoint is set correctly (just in case super() didn't set it or overwrote it)
         self.endpoint = endpoint
@@ -62,14 +67,16 @@ class CsgXnetApi(HfApi):
         if not endpoint_arg:
             endpoint_arg = self._endpoint
             
-        # Ensure token is passed
-        if 'token' not in kwargs and self._token:
+        # Always explicitly set token when caller did not provide one or
+        # provided None. Use self._token (which is False when CSGHub has no
+        # token) to prevent HuggingFace's implicit token fallback.
+        if 'token' not in kwargs or kwargs['token'] is None:
              kwargs['token'] = self._token
              
-        # Ensure token is passed
+        # Ensure cache_dir is passed
         if 'cache_dir' not in kwargs:
             kwargs['cache_dir'] = self._cache_dir
-            
+
         try:
              # Try passing endpoint if HfApi accepts it
              if endpoint_arg:
@@ -98,11 +105,13 @@ class CsgXnetApi(HfApi):
         if 'endpoint' not in kwargs:
             kwargs['endpoint'] = self._endpoint
             
-        # Ensure token is passed
-        if 'token' not in kwargs and self._token:
+        # Always explicitly set token when caller did not provide one or
+        # provided None. Use self._token (which is False when CSGHub has no
+        # token) to prevent HuggingFace's implicit token fallback.
+        if 'token' not in kwargs or kwargs['token'] is None:
             kwargs['token'] = self._token
             
-        # Ensure token is passed
+        # Ensure cache_dir is passed
         if 'cache_dir' not in kwargs:
             kwargs['cache_dir'] = self._cache_dir
 

--- a/pycsghub/test/get_api_test.py
+++ b/pycsghub/test/get_api_test.py
@@ -1,9 +1,10 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 from pycsghub.api_client import get_csghub_api, CsghubApi, CsgXnetApi
 
+
 class TestGetCsghubApi(unittest.TestCase):
-    
+
     @patch('pycsghub.api_client.disable_xnet')
     @patch('pycsghub.api_client.get_token_to_send')
     @patch('pycsghub.api_client.get_endpoint')
@@ -12,10 +13,10 @@ class TestGetCsghubApi(unittest.TestCase):
         mock_disable_xnet.return_value = False
         mock_token.return_value = "fake_token"
         mock_endpoint.return_value = "https://example.com"
-        
+
         # Call
         api = get_csghub_api(token="fake_token", endpoint="https://example.com")
-        
+
         # Assert
         self.assertIsInstance(api, CsgXnetApi)
         self.assertEqual(api._token, "fake_token")
@@ -24,7 +25,7 @@ class TestGetCsghubApi(unittest.TestCase):
         # Since we didn't mock get_xnet_endpoint, it will use the real one which appends 'hf'
         # So we expect "https://example.com/hf"
         self.assertEqual(api._endpoint, "https://example.com/hf")
-        
+
     @patch('pycsghub.api_client.disable_xnet')
     @patch('pycsghub.api_client.get_token_to_send')
     @patch('pycsghub.api_client.get_endpoint')
@@ -33,14 +34,163 @@ class TestGetCsghubApi(unittest.TestCase):
         mock_disable_xnet.return_value = True
         mock_token.return_value = "fake_token"
         mock_endpoint.return_value = "https://example.com"
-        
+
         # Call
         api = get_csghub_api(token="fake_token", endpoint="https://example.com")
-        
+
         # Assert
         self.assertIsInstance(api, CsghubApi)
         self.assertEqual(api._token, "fake_token")
         self.assertEqual(api._endpoint, "https://example.com")
+
+    @patch('pycsghub.api_client.disable_xnet')
+    @patch('pycsghub.api_client.get_token_to_send')
+    @patch('pycsghub.api_client.get_endpoint')
+    def test_csgxnetapi_no_token_returns_false(self, mock_endpoint, mock_token, mock_disable_xnet):
+        """When get_token_to_send returns None (no CSGHub token available),
+        CsgXnetApi should store False instead of None to prevent HuggingFace's
+        implicit token fallback (Issue #129)."""
+        # Setup
+        mock_disable_xnet.return_value = False
+        mock_token.return_value = None  # No CSGHub token found
+        mock_endpoint.return_value = "https://example.com"
+
+        # Call
+        api = get_csghub_api(endpoint="https://example.com")
+
+        # Assert
+        self.assertIsInstance(api, CsgXnetApi)
+        self.assertEqual(api._token, False)  # None → False to prevent HF fallback
+
+    @patch('pycsghub.api_client.disable_xnet')
+    @patch('pycsghub.api_client.get_token_to_send')
+    @patch('pycsghub.api_client.get_endpoint')
+    def test_csgxnetapi_with_token_stores_string(self, mock_endpoint, mock_token, mock_disable_xnet):
+        """When a valid CSGHub token is provided, CsgXnetApi should store it as-is."""
+        # Setup
+        mock_disable_xnet.return_value = False
+        mock_token.return_value = "my_csg_token"
+        mock_endpoint.return_value = "https://example.com"
+
+        # Call
+        api = get_csghub_api(token="my_csg_token", endpoint="https://example.com")
+
+        # Assert
+        self.assertIsInstance(api, CsgXnetApi)
+        self.assertEqual(api._token, "my_csg_token")
+
+    @patch('pycsghub.api_client.disable_xnet')
+    @patch('pycsghub.api_client.get_token_to_send')
+    @patch('pycsghub.api_client.get_endpoint')
+    def test_csgxnetapi_snapshot_download_no_token_passes_false(self, mock_endpoint, mock_token, mock_disable_xnet):
+        """When CsgXnetApi has no token (self._token=False), snapshot_download
+        should pass token=False to HuggingFace's snapshot_download, NOT token=None,
+        to prevent implicit HF token fallback (Issue #129)."""
+        # Setup
+        mock_disable_xnet.return_value = False
+        mock_token.return_value = None  # No CSGHub token
+        mock_endpoint.return_value = "https://example.com"
+
+        api = get_csghub_api(endpoint="https://example.com")
+
+        # Mock the origin_snapshot_download to capture kwargs
+        with patch('huggingface_hub.snapshot_download') as mock_snapshot:
+            mock_snapshot.return_value = "/fake/path"
+            api.snapshot_download(repo_id="test/repo")
+
+            # Verify that token=False was passed (not None)
+            call_kwargs = mock_snapshot.call_args[1]
+            self.assertEqual(call_kwargs['token'], False)
+
+    @patch('pycsghub.api_client.disable_xnet')
+    @patch('pycsghub.api_client.get_token_to_send')
+    @patch('pycsghub.api_client.get_endpoint')
+    def test_csgxnetapi_snapshot_download_with_token_passes_string(self, mock_endpoint, mock_token, mock_disable_xnet):
+        """When CsgXnetApi has a token, snapshot_download should pass it correctly."""
+        # Setup
+        mock_disable_xnet.return_value = False
+        mock_token.return_value = "my_csg_token"
+        mock_endpoint.return_value = "https://example.com"
+
+        api = get_csghub_api(token="my_csg_token", endpoint="https://example.com")
+
+        # Mock the origin_snapshot_download to capture kwargs
+        with patch('huggingface_hub.snapshot_download') as mock_snapshot:
+            mock_snapshot.return_value = "/fake/path"
+            api.snapshot_download(repo_id="test/repo")
+
+            # Verify that the CSGHub token was passed
+            call_kwargs = mock_snapshot.call_args[1]
+            self.assertEqual(call_kwargs['token'], "my_csg_token")
+
+    @patch('pycsghub.api_client.disable_xnet')
+    @patch('pycsghub.api_client.get_token_to_send')
+    @patch('pycsghub.api_client.get_endpoint')
+    def test_csgxnetapi_hf_hub_download_no_token_passes_false(self, mock_endpoint, mock_token, mock_disable_xnet):
+        """When CsgXnetApi has no token (self._token=False), hf_hub_download
+        should pass token=False to HuggingFace's hf_hub_download (Issue #129)."""
+        # Setup
+        mock_disable_xnet.return_value = False
+        mock_token.return_value = None  # No CSGHub token
+        mock_endpoint.return_value = "https://example.com"
+
+        api = get_csghub_api(endpoint="https://example.com")
+
+        # Mock the origin_hf_hub_download (functional fallback path)
+        with patch('huggingface_hub.hf_hub_download') as mock_download:
+            mock_download.return_value = "/fake/file"
+            # The method first tries super().hf_hub_download which will also
+            # hit the mock since we're patching at the module level.
+            # We need to also mock the super call so it fails and falls through
+            # to the functional call.
+            with patch.object(type(api).__bases__[0], 'hf_hub_download', side_effect=TypeError("mocked")):
+                api.hf_hub_download(repo_id="test/repo", filename="config.json")
+
+                # Verify that token=False was passed in the fallback path
+                call_kwargs = mock_download.call_args[1]
+                self.assertEqual(call_kwargs['token'], False)
+
+    @patch('pycsghub.api_client.disable_xnet')
+    @patch('pycsghub.api_client.get_token_to_send')
+    @patch('pycsghub.api_client.get_endpoint')
+    def test_csgxnetapi_hf_hub_download_token_none_in_kwargs_overridden(self, mock_endpoint, mock_token, mock_disable_xnet):
+        """When kwargs contains token=None (e.g., from CLI passing -k without value),
+        CsgXnetApi should override it with self._token (False) to prevent HF fallback."""
+        # Setup
+        mock_disable_xnet.return_value = False
+        mock_token.return_value = None  # No CSGHub token
+        mock_endpoint.return_value = "https://example.com"
+
+        api = get_csghub_api(endpoint="https://example.com")
+
+        # Mock the super call to capture kwargs
+        with patch.object(type(api).__bases__[0], 'hf_hub_download', return_value="/fake/file") as mock_super:
+            api.hf_hub_download(repo_id="test/repo", filename="config.json", token=None)
+
+            # Verify that token was overridden from None to False
+            call_kwargs = mock_super.call_args[1]
+            self.assertEqual(call_kwargs['token'], False)
+
+    @patch('pycsghub.api_client.disable_xnet')
+    @patch('pycsghub.api_client.get_token_to_send')
+    @patch('pycsghub.api_client.get_endpoint')
+    def test_csgxnetapi_explicit_token_not_overridden(self, mock_endpoint, mock_token, mock_disable_xnet):
+        """When kwargs contains an explicit token string, CsgXnetApi should NOT override it."""
+        # Setup
+        mock_disable_xnet.return_value = False
+        mock_token.return_value = "default_csg_token"
+        mock_endpoint.return_value = "https://example.com"
+
+        api = get_csghub_api(token="default_csg_token", endpoint="https://example.com")
+
+        # Mock the super call to capture kwargs
+        with patch.object(type(api).__bases__[0], 'hf_hub_download', return_value="/fake/file") as mock_super:
+            api.hf_hub_download(repo_id="test/repo", filename="config.json", token="explicit_override_token")
+
+            # Verify that the explicit token was preserved
+            call_kwargs = mock_super.call_args[1]
+            self.assertEqual(call_kwargs['token'], "explicit_override_token")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #129 — `csghub-cli` incorrectly picks up the HuggingFace CLI token when no CSGHub token is provided, causing public resource download failures.

## Root Cause

In HuggingFace's token semantics:
- `token=None` → "implicitly use cached token" (falls back to `HF_TOKEN` env or `~/.cache/huggingface/token`)
- `token=False` → "explicitly do NOT send any auth token"

When CSGHub has no token (no `-k`, no `CSGHUB_TOKEN` env, no token file), `CsgXnetApi` stored `self._token = None` and passed `token=None` to HF functions. This triggered HF's credential store lookup, sending an unrelated HF token to CSGHub's server — where it's invalid, causing download failures.

## Fix

Convert `None` to `False` in `CsgXnetApi` and always pass `token` explicitly to HuggingFace functions:

| Location | Change |
|---|---|
| `CsgXnetApi.__init__` line 24 | `self._token = token if token is not None else False` |
| `CsgXnetApi.__init__` line 59 | `super().__init__(endpoint=endpoint, token=self._token)` |
| `CsgXnetApi.hf_hub_download` line 73 | `if 'token' not in kwargs or kwargs['token'] is None:` |
| `CsgXnetApi.snapshot_download` line 111 | `if 'token' not in kwargs or kwargs['token'] is None:` |

This is localized to `CsgXnetApi` only — `CsghubApi` (code/mcp/skill repos) uses its own HTTP stack and is unaffected.

## Testing

Added 6 new unit tests in `pycsghub/test/get_api_test.py`:
- No CSGHub token → `_token` stores `False` (not `None`)
- With CSGHub token → `_token` stores string as-is
- `snapshot_download` passes `token=False` when no CSGHub token
- `snapshot_download` passes token string when CSGHub token provided
- `hf_hub_download` passes `token=False` in fallback path
- `hf_hub_download` overrides `token=None` in kwargs to `False`
- Explicit token string in kwargs is NOT overridden

All 9 tests pass (2 existing + 7 new).